### PR TITLE
Corrected an error in sky130_fd_pr__nfet_g5v0d16v0__ss_discrete.corne…

### DIFF
--- a/cells/nfet_g5v0d16v0/sky130_fd_pr__nfet_g5v0d16v0__ss_discrete.corner.spice
+++ b/cells/nfet_g5v0d16v0/sky130_fd_pr__nfet_g5v0d16v0__ss_discrete.corner.spice
@@ -15,7 +15,6 @@
 * SKY130 Spice File.
 * Number of bins: 05
 .param
-.param
 + sky130_fd_pr__nfet_g5v0d16v0__toxe_mult = 1.042
 + sky130_fd_pr__nfet_g5v0d16v0__overlap_mult = 1.9012
 + sky130_fd_pr__nfet_g5v0d16v0__ajunction_mult = 1.1193e+0


### PR DESCRIPTION
…r.spice;

there is a ".param" line with nothing else on the line.  Xyce at least considers this an error.  Thanks to Sam Crow for reporting the issue.