### PR TITLE
Copied missing monte carlo parameters from discrete to combined models

### DIFF
--- a/combined_models/parameters/critical.spice
+++ b/combined_models/parameters/critical.spice
@@ -15,12 +15,141 @@
 * SKY130 Spice File.
 * Critical Model Parameters:
 .param cnwvc = 0.0 + MC_PR_SWITCH*AGAUSS(0,1.0,1)
-
+.param diff_cd = 0.0 + MC_PR_SWITCH*AGAUSS(0,1.5,1)
+.param hvn_bodyeffect = 0.0 + MC_PR_SWITCH*AGAUSS(0,2.8,1)
+.param hvn_diode = 0.0 + MC_PR_SWITCH*AGAUSS(0,1.0,1)
+.param hvn_mobility = 0.0 + MC_PR_SWITCH*AGAUSS(0,0.8,1)
+.param hvn_saturation = 0.0 + MC_PR_SWITCH*AGAUSS(0,0.6,1)
+.param hvn_subvt = 0.0 + MC_PR_SWITCH*AGAUSS(0,1.0,1)
+.param hvn_threshold = 0.0 + MC_PR_SWITCH*AGAUSS(0,1.5,1)
+.param hvp_bodyeffect = 0.0 + MC_PR_SWITCH*AGAUSS(0,2.8,1)
+.param hvp_diode = 0.0 + MC_PR_SWITCH*AGAUSS(0,1.0,1)
+.param hvp_mobility = 0.0 + MC_PR_SWITCH*AGAUSS(0,1.8,1)
+.param hvp_saturation = 0.0 + MC_PR_SWITCH*AGAUSS(0,1.8,1)
+.param hvp_subvt = 0.0 + MC_PR_SWITCH*AGAUSS(0,1.0,1)
+.param hvp_threshold = 0.0 + MC_PR_SWITCH*AGAUSS(0,1.5,1)
+.param hvtox = 0.0 + MC_PR_SWITCH*AGAUSS(0,1.0,1)
+.param ic_cap = 0.0 + MC_PR_SWITCH*AGAUSS(0,1.0,1)
+.param ic_res = 0.0 + MC_PR_SWITCH*AGAUSS(0,1.0,1)
+.param ic_res_ndiff = 0.0 + MC_PR_SWITCH*AGAUSS(0,1.0,1)
+.param ic_res_pdiff = 0.0 + MC_PR_SWITCH*AGAUSS(0,1.0,1)
+.param ic_res_poly = 0.0 + MC_PR_SWITCH*AGAUSS(0,1.0,1)
+.param ic_res_pwell = 0.0 + MC_PR_SWITCH*AGAUSS(0,1.0,1)
+.param lvhp_bodyeffect = 0.0 + MC_PR_SWITCH*AGAUSS(0,1.8,1)
+.param lvhp_mobility = 0.0 + MC_PR_SWITCH*AGAUSS(0,2.0,1)
+.param lvhp_saturation = 0.0 + MC_PR_SWITCH*AGAUSS(0,1.1,1)
+.param lvhp_threshold = 0.0 + MC_PR_SWITCH*AGAUSS(0,0.8,1)
+.param lvln_bodyeffect = 0.0 + MC_PR_SWITCH*AGAUSS(0,2.0,1)
+.param lvln_mobility = 0.0 + MC_PR_SWITCH*AGAUSS(0,0.6,1)
+.param lvln_saturation = 0.0 + MC_PR_SWITCH*AGAUSS(0,0.6,1)
+.param lvln_threshold = 0.0 + MC_PR_SWITCH*AGAUSS(0,0.6,1)
+.param lvlp_bodyeffect = 0.0 + MC_PR_SWITCH*AGAUSS(0,0.5,1)
+.param lvlp_mobility = 0.0 + MC_PR_SWITCH*AGAUSS(0,0.3,1)
+.param lvlp_saturation = 0.0 + MC_PR_SWITCH*AGAUSS(0,0.3,1)
+.param lvlp_threshold = 0.0 + MC_PR_SWITCH*AGAUSS(0,1.3,1)
+.param lvn_bodyeffect = 0.0 + MC_PR_SWITCH*AGAUSS(0,2.0,1)
+.param lvn_diode = 0.0 + MC_PR_SWITCH*AGAUSS(0,1.0,1)
+.param lvn_mobility = 0.0 + MC_PR_SWITCH*AGAUSS(0,0.6,1)
+.param lvn_saturation = 0.0 + MC_PR_SWITCH*AGAUSS(0,0.6,1)
+.param lvn_subvt = 0.0 + MC_PR_SWITCH*AGAUSS(0,1.0,1)
+.param lvn_threshold = 0.0 + MC_PR_SWITCH*AGAUSS(0,0.8,1)
+.param lvp_bodyeffect = 0.0 + MC_PR_SWITCH*AGAUSS(0,1.0,1)
+.param lvp_diode = 0.0 + MC_PR_SWITCH*AGAUSS(0,1.0,1)
+.param lvp_mobility = 0.0 + MC_PR_SWITCH*AGAUSS(0,2.0,1)
+.param lvp_saturation = 0.0 + MC_PR_SWITCH*AGAUSS(0,1.1,1)
+.param lvp_subvt = 0.0 + MC_PR_SWITCH*AGAUSS(0,1.0,1)
+.param lvp_threshold = 0.0 + MC_PR_SWITCH*AGAUSS(0,1.0,1)
+.param lvtox = 0.0 + MC_PR_SWITCH*AGAUSS(0,1.1,1)
+.param mim = 0.0 + MC_PR_SWITCH*AGAUSS(0,1.0,1)
+.param hvntvn_threshold = 0.0 + MC_PR_SWITCH*AGAUSS(0,1.0,1)
+.param nfet_20v0_nvt = 0.0 + MC_PR_SWITCH*AGAUSS(0,1.0,1)
+.param nfet_20v0_nvt_iso = 0.0 + MC_PR_SWITCH*AGAUSS(0,1.0,1)
+.param nfet_20v0 = 0.0 + MC_PR_SWITCH*AGAUSS(0,1.0,1)
+.param nfet_20v0_iso = 0.0 + MC_PR_SWITCH*AGAUSS(0,1.0,1)
+.param n20zvtvh1defet = 0.0 + MC_PR_SWITCH*AGAUSS(0,1.0,1)
+.param nfet_20v0_zvt = 0.0 + MC_PR_SWITCH*AGAUSS(0,1.0,1)
+.param ndiff_cd = 0.0 + MC_PR_SWITCH*AGAUSS(0,1.5,1)
+.param pfet_20v0 = 0.0 + MC_PR_SWITCH*AGAUSS(0,1.0,1)
+.param pdiff_cd = 0.0 + MC_PR_SWITCH*AGAUSS(0,1.5,1)
+.param nfet_01v8_lvt = 0.0 + MC_PR_SWITCH*AGAUSS(0,1.0,1)
 .param special_nfet_pass_lvt = 0.0 + MC_PR_SWITCH*AGAUSS(0,1.0,1)
+.param sky130_fd_pr__npn_05v5_all = 0.0 + MC_PR_SWITCH*AGAUSS(0,1.0,1)
+.param nfet_g5v0d16v0 = 0.0 + MC_PR_SWITCH*AGAUSS(0,1.0,1)
+.param pfet_01v8_mvt = 0.0 + MC_PR_SWITCH*AGAUSS(0,1.0,1)
+.param pnp_05v5_W0p68L0p68 = 0.0 + MC_PR_SWITCH*AGAUSS(0,1.0,1)
+.param poly_cd = 0.0 + MC_PR_SWITCH*AGAUSS(0,1.5,1)
+.param pfet_01v8 = 0.0 + MC_PR_SWITCH*AGAUSS(0,1.0,1)
+.param pfet_g5v0d16v0 = 0.0 + MC_PR_SWITCH*AGAUSS(0,1.0,1)
+.param well_diode = 0.0 + MC_PR_SWITCH*AGAUSS(0,1.0,1)
 * statistics {
 *  process {
 *     vary cnwvc dist=gauss std=1.0
+*     vary diff_cd dist=gauss std=1.5
+*     vary hvn_bodyeffect dist=gauss std=2.8
+*     vary hvn_diode dist=gauss std=1.0
+*     vary hvn_mobility dist=gauss std=0.8
+*     vary hvn_saturation dist=gauss std=0.6
+*     vary hvn_subvt dist=gauss std=1.0
+*     vary hvn_threshold dist=gauss std=1.5
+*     vary hvp_bodyeffect dist=gauss std=2.8
+*     vary hvp_diode dist=gauss std=1.0
+*     vary hvp_mobility dist=gauss std=1.8
+*     vary hvp_saturation dist=gauss std=1.8
+*     vary hvp_subvt dist=gauss std=1.0
+*     vary hvp_threshold dist=gauss std=1.5
+*     vary hvtox dist=gauss std=1.0
+*     vary ic_cap dist=gauss std=1.0
+*     vary ic_res dist=gauss std=1.0
+*     vary ic_res_ndiff dist=gauss std=1.0
+*     vary ic_res_pdiff dist=gauss std=1.0
+*     vary ic_res_poly dist=gauss std=1.0
+*     vary ic_res_pwell dist=gauss std=1.0
+*     vary lvhp_bodyeffect dist=gauss std=1.8
+*     vary lvhp_mobility dist=gauss std=2.0
+*     vary lvhp_saturation dist=gauss std=1.1
+*     vary lvhp_threshold dist=gauss std=0.8
+*     vary lvln_bodyeffect dist=gauss std=2.0
+*     vary lvln_mobility dist=gauss std=0.6
+*     vary lvln_saturation dist=gauss std=0.6
+*     vary lvln_threshold dist=gauss std=0.6
+*     vary lvlp_bodyeffect dist=gauss std=0.5
+*     vary lvlp_mobility dist=gauss std=0.3
+*     vary lvlp_saturation dist=gauss std=0.3
+*     vary lvlp_threshold dist=gauss std=1.3
+*     vary lvn_bodyeffect dist=gauss std=2.0
+*     vary lvn_diode dist=gauss std=1.0
+*     vary lvn_mobility dist=gauss std=0.6
+*     vary lvn_saturation dist=gauss std=0.6
+*     vary lvn_subvt dist=gauss std=1.0
+*     vary lvn_threshold dist=gauss std=0.8
+*     vary lvp_bodyeffect dist=gauss std=1.0
+*     vary lvp_diode dist=gauss std=1.0
+*     vary lvp_mobility dist=gauss std=2.0
+*     vary lvp_saturation dist=gauss std=1.1
+*     vary lvp_subvt dist=gauss std=1.0
+*     vary lvp_threshold dist=gauss std=1.0
+*     vary lvtox dist=gauss std=1.1
+*     vary mim dist=gauss std=1.0
+*     vary hvntvn_threshold dist=gauss std=1.0
+*     vary nfet_20v0_nvt dist=gauss std=1.0
+*     vary nfet_20v0_nvt_iso dist=gauss std=1.0
+*     vary nfet_20v0 dist=gauss std=1.0
+*     vary nfet_20v0_iso dist=gauss std=1.0
+*     vary n20zvtvh1defet dist=gauss std=1.0
+*     vary nfet_20v0_zvt dist=gauss std=1.0
+*     vary ndiff_cd dist=gauss std=1.5
+*     vary pfet_20v0 dist=gauss std=1.0
+*     vary pdiff_cd dist=gauss std=1.5
+*     vary nfet_01v8_lvt dist=gauss std=1.0
 *     vary special_nfet_pass_lvt dist=gauss std=1.0
+*     vary sky130_fd_pr__npn_05v5_all dist=gauss std=1.0
+*     vary nfet_g5v0d16v0 dist=gauss std=1.0
+*     vary pfet_01v8_mvt dist=gauss std=1.0
+*     vary pnp_05v5_W0p68L0p68 dist=gauss std=1.0
+*     vary poly_cd dist=gauss std=1.5
+*     vary pfet_01v8 dist=gauss std=1.0
+*     vary pfet_g5v0d16v0 dist=gauss std=1.0
+*     vary well_diode dist=gauss std=1.0
 *   }
 *   mismatch {
 *   }

--- a/combined_models/parameters/montecarlo.spice
+++ b/combined_models/parameters/montecarlo.spice
@@ -35,6 +35,10 @@
 * Derivative Parameters:
 *----------------------------------------------------------
 .param
++ lv_dlc_rotweak = .00e-9
++ lvhvt_dlc_rotweak = .00e-9
++ lvt_dlc_rotweak = .00e-9
++ hv_dlc_rotweak = .00e-9
 + cnwvc2_cdepmult = '-1.25000e-02*cnwvc+1.00000e+00'
 + cnwvc2_cintmult = '-1.25000e-02*cnwvc+1.00000e+00'
 + cnwvc2_dlc = '-2.50000e-03*cnwvc'


### PR DESCRIPTION
Copied some missing parameters from the discrete models to the monte carlo parameter file in the combined models, which allows monte carlo simulations to run using the combined models. Otherwise ngspice throws missing parameter errors.