### PR TITLE
Added the 0.36 and 0.39um width nFET and pFET devices to the combined models.

### DIFF
--- a/cells/nfet_01v8/sky130_fd_pr__nfet_01v8.pm3.spice
+++ b/cells/nfet_01v8/sky130_fd_pr__nfet_01v8.pm3.spice
@@ -27,6 +27,13 @@
 *     vary sky130_fd_pr__nfet_01v8__nfactor_slope_spectre dist=gauss std = 1.0
 *   }
 * }
+* "special" standard cell nFET (w < 0.42um) is defined as a regular nFET because its model bins exist there.
+.subckt  sky130_fd_pr__special_nfet_01v8 d g s b
++
+.param  l = 1 w = 1 nf = 1.0 ad = 0 as = 0 pd = 0 ps = 0 nrd = 0 nrs = 0 sa = 0 sb = 0 sd = 0 mult = 1
+xsky130_fd_pr__nfet_01v8 d g s b sky130_fd_pr__nfet_01v8 l = {l} w = {w} nf = {nf} ad = {ad} as = {as} pd = {pd} ps = {ps} nrd = {nrd} nrs = {nrs} sa = {sa} sb = {sb} sd = {sd}
+.ends
+
 .subckt  sky130_fd_pr__nfet_01v8 d g s b
 + 
 .param  l = 1 w = 1 nf = 1.0 ad = 0 as = 0 pd = 0 ps = 0 nrd = 0 nrs = 0 sa = 0 sb = 0 sd = 0 mult = 1

--- a/cells/nfet_01v8/sky130_fd_pr__nfet_01v8__ff.pm3.spice
+++ b/cells/nfet_01v8/sky130_fd_pr__nfet_01v8__ff.pm3.spice
@@ -25,6 +25,13 @@
 *     vary sky130_fd_pr__nfet_01v8__voff_slope_spectre dist=gauss std = 1.0
 *   }
 * }
+* "special" standard cell nFET (w < 0.42um) is defined as a regular nFET because its model bins exist there.
+.subckt  sky130_fd_pr__special_nfet_01v8 d g s b
++
+.param  l = 1 w = 1 nf = 1.0 ad = 0 as = 0 pd = 0 ps = 0 nrd = 0 nrs = 0 sa = 0 sb = 0 sd = 0 mult = 1
+xsky130_fd_pr__nfet_01v8 d g s b sky130_fd_pr__nfet_01v8 l = {l} w = {w} nf = {nf} ad = {ad} as = {as} pd = {pd} ps = {ps} nrd = {nrd} nrs = {nrs} sa = {sa} sb = {sb} sd = {sd}
+.ends
+
 .subckt  sky130_fd_pr__nfet_01v8 d g s b
 + 
 .param  l = 1 w = 1 nf = 1.0 ad = 0 as = 0 pd = 0 ps = 0 nrd = 0 nrs = 0 sa = 0 sb = 0 sd = 0 mult = 1

--- a/cells/nfet_01v8/sky130_fd_pr__nfet_01v8__fs.pm3.spice
+++ b/cells/nfet_01v8/sky130_fd_pr__nfet_01v8__fs.pm3.spice
@@ -25,6 +25,13 @@
 *     vary sky130_fd_pr__nfet_01v8__voff_slope_spectre dist=gauss std = 1.0
 *   }
 * }
+* "special" standard cell nFET (w < 0.42um) is defined as a regular nFET because its model bins exist there.
+.subckt  sky130_fd_pr__special_nfet_01v8 d g s b
++
+.param  l = 1 w = 1 nf = 1.0 ad = 0 as = 0 pd = 0 ps = 0 nrd = 0 nrs = 0 sa = 0 sb = 0 sd = 0 mult = 1
+xsky130_fd_pr__nfet_01v8 d g s b sky130_fd_pr__nfet_01v8 l = {l} w = {w} nf = {nf} ad = {ad} as = {as} pd = {pd} ps = {ps} nrd = {nrd} nrs = {nrs} sa = {sa} sb = {sb} sd = {sd}
+.ends
+
 .subckt  sky130_fd_pr__nfet_01v8 d g s b
 + 
 .param  l = 1 w = 1 nf = 1.0 ad = 0 as = 0 pd = 0 ps = 0 nrd = 0 nrs = 0 sa = 0 sb = 0 sd = 0 mult = 1

--- a/cells/nfet_01v8/sky130_fd_pr__nfet_01v8__leak.pm3.spice
+++ b/cells/nfet_01v8/sky130_fd_pr__nfet_01v8__leak.pm3.spice
@@ -25,6 +25,13 @@
 *     vary sky130_fd_pr__nfet_01v8__voff_slope_spectre dist=gauss std = 1.0
 *   }
 * }
+* "special" standard cell nFET (w < 0.42um) is defined as a regular nFET because its model bins exist there.
+.subckt  sky130_fd_pr__special_nfet_01v8 d g s b
++
+.param  l = 1 w = 1 nf = 1.0 ad = 0 as = 0 pd = 0 ps = 0 nrd = 0 nrs = 0 sa = 0 sb = 0 sd = 0 mult = 1
+xsky130_fd_pr__nfet_01v8 d g s b sky130_fd_pr__nfet_01v8 l = {l} w = {w} nf = {nf} ad = {ad} as = {as} pd = {pd} ps = {ps} nrd = {nrd} nrs = {nrs} sa = {sa} sb = {sb} sd = {sd}
+.ends
+
 .subckt  sky130_fd_pr__nfet_01v8 d g s b
 + 
 .param  l = 1 w = 1 nf = 1.0 ad = 0 as = 0 pd = 0 ps = 0 nrd = 0 nrs = 0 sa = 0 sb = 0 sd = 0 mult = 1

--- a/cells/nfet_01v8/sky130_fd_pr__nfet_01v8__sf.pm3.spice
+++ b/cells/nfet_01v8/sky130_fd_pr__nfet_01v8__sf.pm3.spice
@@ -25,6 +25,13 @@
 *     vary sky130_fd_pr__nfet_01v8__voff_slope_spectre dist=gauss std = 1.0
 *   }
 * }
+* "special" standard cell nFET (w < 0.42um) is defined as a regular nFET because its model bins exist there.
+.subckt  sky130_fd_pr__special_nfet_01v8 d g s b
++
+.param  l = 1 w = 1 nf = 1.0 ad = 0 as = 0 pd = 0 ps = 0 nrd = 0 nrs = 0 sa = 0 sb = 0 sd = 0 mult = 1
+xsky130_fd_pr__nfet_01v8 d g s b sky130_fd_pr__nfet_01v8 l = {l} w = {w} nf = {nf} ad = {ad} as = {as} pd = {pd} ps = {ps} nrd = {nrd} nrs = {nrs} sa = {sa} sb = {sb} sd = {sd}
+.ends
+
 .subckt  sky130_fd_pr__nfet_01v8 d g s b
 + 
 .param  l = 1 w = 1 nf = 1.0 ad = 0 as = 0 pd = 0 ps = 0 nrd = 0 nrs = 0 sa = 0 sb = 0 sd = 0 mult = 1

--- a/cells/nfet_01v8/sky130_fd_pr__nfet_01v8__ss.pm3.spice
+++ b/cells/nfet_01v8/sky130_fd_pr__nfet_01v8__ss.pm3.spice
@@ -25,6 +25,13 @@
 *     vary sky130_fd_pr__nfet_01v8__voff_slope_spectre dist=gauss std = 1.0
 *   }
 * }
+* "special" standard cell nFET (w < 0.42um) is defined as a regular nFET because its model bins exist there.
+.subckt  sky130_fd_pr__special_nfet_01v8 d g s b
++
+.param  l = 1 w = 1 nf = 1.0 ad = 0 as = 0 pd = 0 ps = 0 nrd = 0 nrs = 0 sa = 0 sb = 0 sd = 0 mult = 1
+xsky130_fd_pr__nfet_01v8 d g s b sky130_fd_pr__nfet_01v8 l = {l} w = {w} nf = {nf} ad = {ad} as = {as} pd = {pd} ps = {ps} nrd = {nrd} nrs = {nrs} sa = {sa} sb = {sb} sd = {sd}
+.ends
+
 .subckt  sky130_fd_pr__nfet_01v8 d g s b
 + 
 .param  l = 1 w = 1 nf = 1.0 ad = 0 as = 0 pd = 0 ps = 0 nrd = 0 nrs = 0 sa = 0 sb = 0 sd = 0 mult = 1

--- a/cells/nfet_01v8/sky130_fd_pr__nfet_01v8__tt.pm3.spice
+++ b/cells/nfet_01v8/sky130_fd_pr__nfet_01v8__tt.pm3.spice
@@ -25,6 +25,13 @@
 *     vary sky130_fd_pr__nfet_01v8__voff_slope_spectre dist=gauss std = 1.0
 *   }
 * }
+* "special" standard cell nFET (w < 0.42um) is defined as a regular nFET because its model bins exist there.
+.subckt  sky130_fd_pr__special_nfet_01v8 d g s b
++
+.param  l = 1 w = 1 nf = 1.0 ad = 0 as = 0 pd = 0 ps = 0 nrd = 0 nrs = 0 sa = 0 sb = 0 sd = 0 mult = 1
+xsky130_fd_pr__nfet_01v8 d g s b sky130_fd_pr__nfet_01v8 l = {l} w = {w} nf = {nf} ad = {ad} as = {as} pd = {pd} ps = {ps} nrd = {nrd} nrs = {nrs} sa = {sa} sb = {sb} sd = {sd}
+.ends
+
 .subckt  sky130_fd_pr__nfet_01v8 d g s b
 + 
 .param  l = 1 w = 1 nf = 1.0 ad = 0 as = 0 pd = 0 ps = 0 nrd = 0 nrs = 0 sa = 0 sb = 0 sd = 0 mult = 1

--- a/cells/nfet_01v8/sky130_fd_pr__nfet_01v8__tt_leak.pm3.spice
+++ b/cells/nfet_01v8/sky130_fd_pr__nfet_01v8__tt_leak.pm3.spice
@@ -25,6 +25,13 @@
 *     vary sky130_fd_pr__nfet_01v8__voff_slope_spectre dist=gauss std = 1.0
 *   }
 * }
+* "special" standard cell nFET (w < 0.42um) is defined as a regular nFET because its model bins exist there.
+.subckt  sky130_fd_pr__special_nfet_01v8 d g s b
++
+.param  l = 1 w = 1 nf = 1.0 ad = 0 as = 0 pd = 0 ps = 0 nrd = 0 nrs = 0 sa = 0 sb = 0 sd = 0 mult = 1
+xsky130_fd_pr__nfet_01v8 d g s b sky130_fd_pr__nfet_01v8 l = {l} w = {w} nf = {nf} ad = {ad} as = {as} pd = {pd} ps = {ps} nrd = {nrd} nrs = {nrs} sa = {sa} sb = {sb} sd = {sd}
+.ends
+
 .subckt  sky130_fd_pr__nfet_01v8 d g s b
 + 
 .param  l = 1 w = 1 nf = 1.0 ad = 0 as = 0 pd = 0 ps = 0 nrd = 0 nrs = 0 sa = 0 sb = 0 sd = 0 mult = 1

--- a/cells/pfet_01v8_hvt/sky130_fd_pr__pfet_01v8_hvt.pm3.spice
+++ b/cells/pfet_01v8_hvt/sky130_fd_pr__pfet_01v8_hvt.pm3.spice
@@ -27,6 +27,13 @@
 *     vary sky130_fd_pr__pfet_01v8_hvt__nfactor_slope_spectre dist=gauss std = 1.0
 *   }
 * }
+* "special" standard cell HVT pFET (w < 0.42um) is defined as a regular HVT pFET because its model bins exist there.
+.subckt  sky130_fd_pr__special_pfet_01v8_hvt d g s b
++
+.param  l = 1 w = 1 nf = 1.0 ad = 0 as = 0 pd = 0 ps = 0 nrd = 0 nrs = 0 sa = 0 sb = 0 sd = 0 mult = 1
+xsky130_fd_pr__pfet_01v8_hvt d g s b sky130_fd_pr__pfet_01v8_hvt l = {l} w = {w} nf = {nf} ad = {ad} as = {as} pd = {pd} ps = {ps} nrd = {nrd} nrs = {nrs} sa = {sa} sb = {sb} sd = {sd}
+.ends
+
 .subckt  sky130_fd_pr__pfet_01v8_hvt d g s b
 + 
 .param  l = 1 w = 1 nf = 1.0 ad = 0 as = 0 pd = 0 ps = 0 nrd = 0 nrs = 0 sa = 0 sb = 0 sd = 0 mult = 1

--- a/cells/pfet_01v8_hvt/sky130_fd_pr__pfet_01v8_hvt__ff.pm3.spice
+++ b/cells/pfet_01v8_hvt/sky130_fd_pr__pfet_01v8_hvt__ff.pm3.spice
@@ -27,6 +27,13 @@
 *     vary sky130_fd_pr__pfet_01v8_hvt__nfactor_slope_spectre dist=gauss std = 1.0
 *   }
 * }
+* "special" standard cell HVT pFET (w < 0.42um) is defined as a regular HVT pFET because its model bins exist there.
+.subckt  sky130_fd_pr__special_pfet_01v8_hvt d g s b
++
+.param  l = 1 w = 1 nf = 1.0 ad = 0 as = 0 pd = 0 ps = 0 nrd = 0 nrs = 0 sa = 0 sb = 0 sd = 0 mult = 1
+xsky130_fd_pr__pfet_01v8_hvt d g s b sky130_fd_pr__pfet_01v8_hvt l = {l} w = {w} nf = {nf} ad = {ad} as = {as} pd = {pd} ps = {ps} nrd = {nrd} nrs = {nrs} sa = {sa} sb = {sb} sd = {sd}
+.ends
+
 .subckt  sky130_fd_pr__pfet_01v8_hvt d g s b
 + 
 .param  l = 1 w = 1 nf = 1.0 ad = 0 as = 0 pd = 0 ps = 0 nrd = 0 nrs = 0 sa = 0 sb = 0 sd = 0 mult = 1

--- a/cells/pfet_01v8_hvt/sky130_fd_pr__pfet_01v8_hvt__fs.pm3.spice
+++ b/cells/pfet_01v8_hvt/sky130_fd_pr__pfet_01v8_hvt__fs.pm3.spice
@@ -27,6 +27,13 @@
 *     vary sky130_fd_pr__pfet_01v8_hvt__nfactor_slope_spectre dist=gauss std = 1.0
 *   }
 * }
+* "special" standard cell HVT pFET (w < 0.42um) is defined as a regular HVT pFET because its model bins exist there.
+.subckt  sky130_fd_pr__special_pfet_01v8_hvt d g s b
++
+.param  l = 1 w = 1 nf = 1.0 ad = 0 as = 0 pd = 0 ps = 0 nrd = 0 nrs = 0 sa = 0 sb = 0 sd = 0 mult = 1
+xsky130_fd_pr__pfet_01v8_hvt d g s b sky130_fd_pr__pfet_01v8_hvt l = {l} w = {w} nf = {nf} ad = {ad} as = {as} pd = {pd} ps = {ps} nrd = {nrd} nrs = {nrs} sa = {sa} sb = {sb} sd = {sd}
+.ends
+
 .subckt  sky130_fd_pr__pfet_01v8_hvt d g s b
 + 
 .param  l = 1 w = 1 nf = 1.0 ad = 0 as = 0 pd = 0 ps = 0 nrd = 0 nrs = 0 sa = 0 sb = 0 sd = 0 mult = 1

--- a/cells/pfet_01v8_hvt/sky130_fd_pr__pfet_01v8_hvt__leak.pm3.spice
+++ b/cells/pfet_01v8_hvt/sky130_fd_pr__pfet_01v8_hvt__leak.pm3.spice
@@ -27,6 +27,13 @@
 *     vary sky130_fd_pr__pfet_01v8_hvt__nfactor_slope_spectre dist=gauss std = 1.0
 *   }
 * }
+* "special" standard cell HVT pFET (w < 0.42um) is defined as a regular HVT pFET because its model bins exist there.
+.subckt  sky130_fd_pr__special_pfet_01v8_hvt d g s b
++
+.param  l = 1 w = 1 nf = 1.0 ad = 0 as = 0 pd = 0 ps = 0 nrd = 0 nrs = 0 sa = 0 sb = 0 sd = 0 mult = 1
+xsky130_fd_pr__pfet_01v8_hvt d g s b sky130_fd_pr__pfet_01v8_hvt l = {l} w = {w} nf = {nf} ad = {ad} as = {as} pd = {pd} ps = {ps} nrd = {nrd} nrs = {nrs} sa = {sa} sb = {sb} sd = {sd}
+.ends
+
 .subckt  sky130_fd_pr__pfet_01v8_hvt d g s b
 + 
 .param  l = 1 w = 1 nf = 1.0 ad = 0 as = 0 pd = 0 ps = 0 nrd = 0 nrs = 0 sa = 0 sb = 0 sd = 0 mult = 1

--- a/cells/pfet_01v8_hvt/sky130_fd_pr__pfet_01v8_hvt__sf.pm3.spice
+++ b/cells/pfet_01v8_hvt/sky130_fd_pr__pfet_01v8_hvt__sf.pm3.spice
@@ -27,6 +27,13 @@
 *     vary sky130_fd_pr__pfet_01v8_hvt__nfactor_slope_spectre dist=gauss std = 1.0
 *   }
 * }
+* "special" standard cell HVT pFET (w < 0.42um) is defined as a regular HVT pFET because its model bins exist there.
+.subckt  sky130_fd_pr__special_pfet_01v8_hvt d g s b
++
+.param  l = 1 w = 1 nf = 1.0 ad = 0 as = 0 pd = 0 ps = 0 nrd = 0 nrs = 0 sa = 0 sb = 0 sd = 0 mult = 1
+xsky130_fd_pr__pfet_01v8_hvt d g s b sky130_fd_pr__pfet_01v8_hvt l = {l} w = {w} nf = {nf} ad = {ad} as = {as} pd = {pd} ps = {ps} nrd = {nrd} nrs = {nrs} sa = {sa} sb = {sb} sd = {sd}
+.ends
+
 .subckt  sky130_fd_pr__pfet_01v8_hvt d g s b
 + 
 .param  l = 1 w = 1 nf = 1.0 ad = 0 as = 0 pd = 0 ps = 0 nrd = 0 nrs = 0 sa = 0 sb = 0 sd = 0 mult = 1

--- a/cells/pfet_01v8_hvt/sky130_fd_pr__pfet_01v8_hvt__ss.pm3.spice
+++ b/cells/pfet_01v8_hvt/sky130_fd_pr__pfet_01v8_hvt__ss.pm3.spice
@@ -27,6 +27,13 @@
 *     vary sky130_fd_pr__pfet_01v8_hvt__nfactor_slope_spectre dist=gauss std = 1.0
 *   }
 * }
+* "special" standard cell HVT pFET (w < 0.42um) is defined as a regular HVT pFET because its model bins exist there.
+.subckt  sky130_fd_pr__special_pfet_01v8_hvt d g s b
++
+.param  l = 1 w = 1 nf = 1.0 ad = 0 as = 0 pd = 0 ps = 0 nrd = 0 nrs = 0 sa = 0 sb = 0 sd = 0 mult = 1
+xsky130_fd_pr__pfet_01v8_hvt d g s b sky130_fd_pr__pfet_01v8_hvt l = {l} w = {w} nf = {nf} ad = {ad} as = {as} pd = {pd} ps = {ps} nrd = {nrd} nrs = {nrs} sa = {sa} sb = {sb} sd = {sd}
+.ends
+
 .subckt  sky130_fd_pr__pfet_01v8_hvt d g s b
 + 
 .param  l = 1 w = 1 nf = 1.0 ad = 0 as = 0 pd = 0 ps = 0 nrd = 0 nrs = 0 sa = 0 sb = 0 sd = 0 mult = 1

--- a/cells/pfet_01v8_hvt/sky130_fd_pr__pfet_01v8_hvt__tt.pm3.spice
+++ b/cells/pfet_01v8_hvt/sky130_fd_pr__pfet_01v8_hvt__tt.pm3.spice
@@ -27,6 +27,13 @@
 *     vary sky130_fd_pr__pfet_01v8_hvt__nfactor_slope_spectre dist=gauss std = 1.0
 *   }
 * }
+* "special" standard cell HVT pFET (w < 0.42um) is defined as a regular HVT pFET because its model bins exist there.
+.subckt  sky130_fd_pr__special_pfet_01v8_hvt d g s b
++
+.param  l = 1 w = 1 nf = 1.0 ad = 0 as = 0 pd = 0 ps = 0 nrd = 0 nrs = 0 sa = 0 sb = 0 sd = 0 mult = 1
+xsky130_fd_pr__pfet_01v8_hvt d g s b sky130_fd_pr__pfet_01v8_hvt l = {l} w = {w} nf = {nf} ad = {ad} as = {as} pd = {pd} ps = {ps} nrd = {nrd} nrs = {nrs} sa = {sa} sb = {sb} sd = {sd}
+.ends
+
 .subckt  sky130_fd_pr__pfet_01v8_hvt d g s b
 + 
 .param  l = 1 w = 1 nf = 1.0 ad = 0 as = 0 pd = 0 ps = 0 nrd = 0 nrs = 0 sa = 0 sb = 0 sd = 0 mult = 1

--- a/cells/pfet_01v8_hvt/sky130_fd_pr__pfet_01v8_hvt__tt_leak.pm3.spice
+++ b/cells/pfet_01v8_hvt/sky130_fd_pr__pfet_01v8_hvt__tt_leak.pm3.spice
@@ -27,6 +27,13 @@
 *     vary sky130_fd_pr__pfet_01v8_hvt__nfactor_slope_spectre dist=gauss std = 1.0
 *   }
 * }
+* "special" standard cell HVT pFET (w < 0.42um) is defined as a regular HVT pFET because its model bins exist there.
+.subckt  sky130_fd_pr__special_pfet_01v8_hvt d g s b
++
+.param  l = 1 w = 1 nf = 1.0 ad = 0 as = 0 pd = 0 ps = 0 nrd = 0 nrs = 0 sa = 0 sb = 0 sd = 0 mult = 1
+xsky130_fd_pr__pfet_01v8_hvt d g s b sky130_fd_pr__pfet_01v8_hvt l = {l} w = {w} nf = {nf} ad = {ad} as = {as} pd = {pd} ps = {ps} nrd = {nrd} nrs = {nrs} sa = {sa} sb = {sb} sd = {sd}
+.ends
+
 .subckt  sky130_fd_pr__pfet_01v8_hvt d g s b
 + 
 .param  l = 1 w = 1 nf = 1.0 ad = 0 as = 0 pd = 0 ps = 0 nrd = 0 nrs = 0 sa = 0 sb = 0 sd = 0 mult = 1

--- a/cells/special_nfet_01v8/sky130_fd_pr__special_nfet_01v8.pm3.spice
+++ b/cells/special_nfet_01v8/sky130_fd_pr__special_nfet_01v8.pm3.spice
@@ -1,0 +1,576 @@
+* Copyright 2020 The SkyWater PDK Authors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+
+* SKY130 Spice File.
+.param sky130_fd_pr__special_nfet_01v8__toxe_slope_spectre = 0.0
+.param sky130_fd_pr__special_nfet_01v8__vth0_slope_spectre = 0.0
+.param sky130_fd_pr__special_nfet_01v8__voff_slope_spectre = 0.0
+.param sky130_fd_pr__special_nfet_01v8__nfactor_slope_spectre = 0.0
+* statistics {
+*   process {
+*   }
+*   mismatch {
+*     vary sky130_fd_pr__special_nfet_01v8__toxe_slope_spectre dist=gauss std = 1.0
+*     vary sky130_fd_pr__special_nfet_01v8__vth0_slope_spectre dist=gauss std = 1.0
+*     vary sky130_fd_pr__special_nfet_01v8__voff_slope_spectre dist=gauss std = 1.0
+*     vary sky130_fd_pr__special_nfet_01v8__nfactor_slope_spectre dist=gauss std = 1.0
+*   }
+* }
+.subckt  sky130_fd_pr__special_nfet_01v8 d g s b
++ 
+.param  l = 1 w = 1 nf = 1.0 ad = 0 as = 0 pd = 0 ps = 0 nrd = 0 nrs = 0 sa = 0 sb = 0 sd = 0 mult = 1
+msky130_fd_pr__special_nfet_01v8 d g s b sky130_fd_pr__special_nfet_01v8__model l = {l} w = {w} nf = {nf} ad = {ad} as = {as} pd = {pd} ps = {ps} nrd = {nrd} nrs = {nrs} sa = {sa} sb = {sb} sd = {sd}
+.model sky130_fd_pr__special_nfet_01v8__model.0 nmos
+* Model Flag Parameters
++ lmin = 1.49e-07 lmax = 1.51e-07 wmin = 3.59e-07 wmax = 3.61e-7
++ level = 54.0
++ version = 4.5
++ binunit = 2.0
++ mobmod = 0.0
++ capmod = 2.0
++ igcmod = 0.0
++ igbmod = 0.0
++ geomod = 0.0
++ diomod = 1.0
++ rdsmod = 0.0
++ rbodymod = 1.0
++ rgatemod = 0.0
++ permod = 1.0
++ acnqsmod = 0.0
++ trnqsmod = 0.0
++ fnoimod = 1.0
++ tnoimod = 1.0
++ tempmod = 0.0
+* Process Parameters
+*(mismatch parameter sky130_fd_pr__special_nfet_01v8__toxe_slope_spectre)
++ toxe = {4.148e-09*sky130_fd_pr__special_nfet_01v8__toxe_mult+MC_MM_SWITCH*AGAUSS(0,1.0,1)*(4.148e-9*sky130_fd_pr__special_nfet_01v8__toxe_mult*(sky130_fd_pr__special_nfet_01v8__toxe_slope/sqrt(l*w*mult)))}
++ toxm = 4.148e-9
++ dtox = 0.0
++ epsrox = 3.9
++ xj = 1.5e-7
++ ngate = 1.0e+23
++ ndep = 1.7e+17
++ nsd = 1.0e+20
++ rsh = {1.0*sky130_fd_pr__special_nfet_01v8__rshn_mult}
++ rshg = 0.1
+* Basic Model Parameters
++ wint = {2.1859e-08+sky130_fd_pr__special_nfet_01v8__wint_diff}
++ lint = {1.1932e-08+sky130_fd_pr__special_nfet_01v8__lint_diff}
+*(mismatch parameter sky130_fd_pr__special_nfet_01v8__vth0_slope_spectre)
++ vth0 = {0.294216+sky130_fd_pr__special_nfet_01v8__vth0_diff_0+MC_MM_SWITCH*AGAUSS(0,1.0,1)*(sky130_fd_pr__special_nfet_01v8__vth0_slope/sqrt(l*w*mult))}
++ k1 = 0.90707349
++ k2 = {-0.164979+sky130_fd_pr__special_nfet_01v8__k2_diff_0}
++ k3 = 2.0
++ k3b = 0.54
++ w0 = 0.0
++ dvt0 = 0.0
++ dvt1 = 0.53
++ dvt2 = -0.032
++ dvt0w = -3.58
++ dvt1w = 1670600.0
++ dvt2w = 0.068
++ dsub = 0.745709255106775
++ minv = 0.0
++ voffl = 5.8197729e-9
++ lpe0 = 1.0325e-7
++ lpeb = -7.082e-8
++ vbm = -3.0
++ dvtp0 = 0.0
++ dvtp1 = 0.0
++ phin = 0.0
++ cdsc = 0.0
++ cdscb = 0.0
++ cdscd = 0.002052
++ cit = 0.0
+*(mismatch parameter sky130_fd_pr__special_nfet_01v8__voff_slope_spectre)
++ voff = {-0.20753+sky130_fd_pr__special_nfet_01v8__voff_diff_0+MC_MM_SWITCH*AGAUSS(0,1.0,1)*(sky130_fd_pr__special_nfet_01v8__voff_slope/sqrt(l*w*mult))}
++ nfactor = {2.11251750684601+sky130_fd_pr__special_nfet_01v8__nfactor_diff_0}
++ eta0 = {0.0+sky130_fd_pr__special_nfet_01v8__eta0_diff_0}
++ etab = -0.043998
++ u0 = {0.0420786+sky130_fd_pr__special_nfet_01v8__u0_diff_0}
++ ua = {-1.21575137545398e-09+sky130_fd_pr__special_nfet_01v8__ua_diff_0}
++ ub = {3.09344567610299e-18+sky130_fd_pr__special_nfet_01v8__ub_diff_0}
++ uc = 5.40303933016111e-11
++ ud = 0.0
++ up = 0.0
++ lp = 1.0
++ eu = 1.67
++ vtl = 0.0
++ xn = 3.0
++ vsat = {205055.7+sky130_fd_pr__special_nfet_01v8__vsat_diff_0}
++ a0 = {1.5+sky130_fd_pr__special_nfet_01v8__a0_diff_0}
++ ags = {1.25+sky130_fd_pr__special_nfet_01v8__ags_diff_0}
++ a1 = 0.0
++ a2 = 0.42385546
++ b0 = {0.0+sky130_fd_pr__special_nfet_01v8__b0_diff_0}
++ b1 = {0.0+sky130_fd_pr__special_nfet_01v8__b1_diff_0}
++ keta = {-0.140717411247685+sky130_fd_pr__special_nfet_01v8__keta_diff_0}
++ dwg = 0.0
++ dwb = 0.0
++ pclm = {0.129289552416565+sky130_fd_pr__special_nfet_01v8__pclm_diff_0}
++ pdiblc1 = 0.35697215
++ pdiblc2 = 0.0084061121
++ pdiblcb = -0.10329577
++ drout = 0.50332666
++ pscbe1 = 791419880.0
++ pscbe2 = 1.0e-12
++ pvag = 0.0
++ delta = 0.01
++ fprout = 0.0
++ pdits = {0.0+sky130_fd_pr__special_nfet_01v8__pdits_diff_0}
++ pditsl = 0.0
++ pditsd = {0.0+sky130_fd_pr__special_nfet_01v8__pditsd_diff_0}
++ lambda = 0.0
++ lc = 5.0e-9
+* Parameters FOR Asymmetric AND Bias-Dependent RDS Model
++ rdsw = {65.968+sky130_fd_pr__special_nfet_01v8__rdsw_diff_0}
++ rsw = 0.0
++ rdw = 0.0
++ rdswmin = 0.0
++ rdwmin = 0.0
++ rswmin = 0.0
++ prwb = 0.0
++ prwg = 0.021507
++ wr = 1.0
+* Impact Ionization Current Model Parameters
++ alpha0 = 2.99999998238709e-8
++ alpha1 = 0.85
++ beta0 = 13.8499999988778
+* Gidl Induced Drain Leakage Model Parameters
++ agidl = 0.0
++ bgidl = 2300000000.0
++ cgidl = 0.5
++ egidl = 0.8
+* Gate Dielectric Tunneling Current Model Parameters
++ toxref = 4.148e-9
++ dlcig = 0.0
++ aigbacc = 1.0
++ bigbacc = 0.0
++ cigbacc = 0.0
++ nigbacc = 0.0
++ aigbinv = 0.35
++ bigbinv = 0.03
++ cigbinv = 0.006
++ eigbinv = 1.1
++ nigbinv = 0.0
++ aigc = 0.43
++ bigc = 0.054
++ cigc = 0.075
++ aigsd = 0.43
++ bigsd = 0.054
++ cigsd = 0.075
++ nigc = 0.0
++ poxedge = 1.0
++ pigcd = 1.0
++ ntox = 1.0
++ vfbsdoff = 0.0
+* Charge AND Capacitance Model Parameters
++ dlc = {1.0494e-08+sky130_fd_pr__special_nfet_01v8__dlc_diff+sky130_fd_pr__special_nfet_01v8__dlc_rotweak}
++ dwc = {0.0+sky130_fd_pr__special_nfet_01v8__dwc_diff}
++ xpart = 0.0
++ cgso = {2.54e-10*sky130_fd_pr__special_nfet_01v8__overlap_mult}
++ cgdo = {2.54e-10*sky130_fd_pr__special_nfet_01v8__overlap_mult}
++ cgbo = 1.0e-13
++ cgdl = {0.0*sky130_fd_pr__special_nfet_01v8__overlap_mult}
++ cgsl = {0.0*sky130_fd_pr__special_nfet_01v8__overlap_mult}
++ clc = 1.0e-7
++ cle = 0.6
++ cf = 1.4067e-12
++ ckappas = 0.6
++ vfbcv = -1.0
++ acde = 0.4
++ moin = 6.9
++ noff = 3.4037
++ voffcv = -0.17287
+* High-Speed/RF Model Parameters
++ xrcrg1 = 12.0
++ xrcrg2 = 1.0
++ rbpb = 50.0
++ rbpd = 50.0
++ rbps = 50.0
++ rbdb = 50.0
++ rbsb = 50.0
++ gbmin = 1.0e-12
+* Flicker AND Thermal Noise Model Parameters
++ ef = 0.84
++ noia = 2.5e+42
++ noib = 0.0
++ noic = 0.0
++ em = 41000000.0
++ ntnoi = 1.0
++ lintnoi = -1.0e-7
++ af = 1.0
++ kf = 0.0
++ tnoia = 15000000.0
++ tnoib = 9900000.0
++ rnoia = 0.94
++ rnoib = 0.26
+* Layout-Dependent Parasitics Model Parameters
++ xl = 0.0
++ xw = 0.0
++ dmcg = 0.0
++ dmdg = 0.0
++ dmcgt = 0.0
++ xgw = 0.0
++ xgl = 0.0
++ ngcon = 1.0
+* Asymmetric Source/Drain Junction Diode Model Parameters
++ jss = 0.00275
++ jsws = 6.0e-10
++ ijthsfwd = 0.1
++ ijthsrev = 0.1
++ bvs = 11.7
++ xjbvs = 1.0
++ pbs = 0.729
++ cjs = {0.0013459*sky130_fd_pr__special_nfet_01v8__ajunction_mult}
++ mjs = 0.44
++ pbsws = 0.2
++ cjsws = {3.6001e-11*sky130_fd_pr__special_nfet_01v8__pjunction_mult}
++ mjsws = 0.0009
++ pbswgs = 0.95578
++ cjswgs = {2.3347e-10*sky130_fd_pr__special_nfet_01v8__pjunction_mult}
++ mjswgs = 0.8
+* Temperature Dependence Parameters
++ tnom = 30.0
++ kt1 = {-0.240960739938925+sky130_fd_pr__special_nfet_01v8__kt1_diff_0}
++ kt2 = -0.028878939
++ at = 53720.4870195945
++ ute = -1.19244645977108
++ ua1 = -2.3847336e-11
++ ub1 = 7.0775317e-19
++ uc1 = 1.4718625e-10
++ kt1l = 0.0
++ prt = 0.0
++ tvoff = {0.0+sky130_fd_pr__special_nfet_01v8__tvoff_diff_0}
++ njs = 1.2928
++ tpb = 0.0012287
++ tcj = 0.000792
++ tpbsw = 0.0
++ tcjsw = 1.0e-5
++ tpbswg = 0.0
++ tcjswg = 0.0
++ xtis = 2.0
++ tvfbsdoff = 0.0
+* DW AND DL Parameters
++ ll = 0.0
++ wl = 0.0
++ lln = 1.0
++ wln = 1.0
++ lw = 0.0
++ ww = 0.0
++ lwn = 1.0
++ wwn = 1.0
++ lwl = 0.0
++ wwl = 0.0
++ llc = 0.0
++ wlc = 0.0
++ lwc = 0.0
++ wwc = 0.0
++ lwlc = 0.0
++ wwlc = 0.0
+* Stress Parameters
++ saref = 1.04e-6
++ sbref = 1.04e-6
++ kvth0 = 9.8e-9
++ lkvth0 = 0.0
++ wkvth0 = 2.0e-7
++ pkvth0 = 0.0
++ llodvth = 0.0
++ wlodvth = 1.0
++ wlod = 0.0
++ stk2 = 0.0
++ lodk2 = 1.0
++ lodeta0 = 1.0
++ ku0 = -2.7e-8
++ lku0 = 0.0
++ wku0 = 0.0
++ pku0 = 0.0
++ tku0 = 0.0
++ llodku0 = 0.0
++ wlodku0 = 1.0
++ kvsat = 0.2
++ steta0 = 0.0
+* Well Proximity Effect Parameters
+.model sky130_fd_pr__special_nfet_01v8__model.0 nmos
+* Model Flag Parameters
++ lmin = 1.49e-07 lmax = 1.51e-07 wmin = 3.89e-07 wmax = 3.91e-7
++ level = 54.0
++ version = 4.5
++ binunit = 2.0
++ mobmod = 0.0
++ capmod = 2.0
++ igcmod = 0.0
++ igbmod = 0.0
++ geomod = 0.0
++ diomod = 1.0
++ rdsmod = 0.0
++ rbodymod = 1.0
++ rgatemod = 0.0
++ permod = 1.0
++ acnqsmod = 0.0
++ trnqsmod = 0.0
++ fnoimod = 1.0
++ tnoimod = 1.0
++ tempmod = 0.0
+* Process Parameters
+*(mismatch parameter sky130_fd_pr__special_nfet_01v8__toxe_slope_spectre)
++ toxe = {4.148e-09*sky130_fd_pr__special_nfet_01v8__toxe_mult+MC_MM_SWITCH*AGAUSS(0,1.0,1)*(4.148e-9*sky130_fd_pr__special_nfet_01v8__toxe_mult*(sky130_fd_pr__special_nfet_01v8__toxe_slope/sqrt(l*w*mult)))}
++ toxm = 4.148e-9
++ dtox = 0.0
++ epsrox = 3.9
++ xj = 1.5e-7
++ ngate = 1.0e+23
++ ndep = 1.7e+17
++ nsd = 1.0e+20
++ rsh = {1.0*sky130_fd_pr__special_nfet_01v8__rshn_mult}
++ rshg = 0.1
+* Basic Model Parameters
++ wint = {2.1859e-08+sky130_fd_pr__special_nfet_01v8__wint_diff}
++ lint = {1.1932e-08+sky130_fd_pr__special_nfet_01v8__lint_diff}
+*(mismatch parameter sky130_fd_pr__special_nfet_01v8__vth0_slope_spectre)
++ vth0 = {0.3288413+sky130_fd_pr__special_nfet_01v8__vth0_diff_1+MC_MM_SWITCH*AGAUSS(0,1.0,1)*(sky130_fd_pr__special_nfet_01v8__vth0_slope/sqrt(l*w*mult))}
++ k1 = 0.90707349
++ k2 = {-0.157868+sky130_fd_pr__special_nfet_01v8__k2_diff_1}
++ k3 = 2.0
++ k3b = 0.54
++ w0 = 0.0
++ dvt0 = 0.0
++ dvt1 = 0.53
++ dvt2 = -0.032
++ dvt0w = -3.58
++ dvt1w = 1670600.0
++ dvt2w = 0.068
++ dsub = 0.679435816074994
++ minv = 0.0
++ voffl = 5.8197729e-9
++ lpe0 = 1.0325e-7
++ lpeb = -7.082e-8
++ vbm = -3.0
++ dvtp0 = 0.0
++ dvtp1 = 0.0
++ phin = 0.0
++ cdsc = 0.0
++ cdscb = 0.0
++ cdscd = 0.002052
++ cit = 0.0
+*(mismatch parameter sky130_fd_pr__special_nfet_01v8__voff_slope_spectre)
++ voff = {-0.20753+sky130_fd_pr__special_nfet_01v8__voff_diff_1+MC_MM_SWITCH*AGAUSS(0,1.0,1)*(sky130_fd_pr__special_nfet_01v8__voff_slope/sqrt(l*w*mult))}
++ nfactor = {2.23668316177219+sky130_fd_pr__special_nfet_01v8__nfactor_diff_1}
++ eta0 = {0.0+sky130_fd_pr__special_nfet_01v8__eta0_diff_1}
++ etab = -0.043998
++ u0 = {0.0392402+sky130_fd_pr__special_nfet_01v8__u0_diff_1}
++ ua = {-1.20664055548599e-09+sky130_fd_pr__special_nfet_01v8__ua_diff_1}
++ ub = {2.8992935911323e-18+sky130_fd_pr__special_nfet_01v8__ub_diff_1}
++ uc = 6.17577815560697e-11
++ ud = 0.0
++ up = 0.0
++ lp = 1.0
++ eu = 1.67
++ vtl = 0.0
++ xn = 3.0
++ vsat = {200231.2+sky130_fd_pr__special_nfet_01v8__vsat_diff_1}
++ a0 = {1.5+sky130_fd_pr__special_nfet_01v8__a0_diff_1}
++ ags = {1.25+sky130_fd_pr__special_nfet_01v8__ags_diff_1}
++ a1 = 0.0
++ a2 = 0.42385546
++ b0 = {0.0+sky130_fd_pr__special_nfet_01v8__b0_diff_1}
++ b1 = {0.0+sky130_fd_pr__special_nfet_01v8__b1_diff_1}
++ keta = {-0.114465726035654+sky130_fd_pr__special_nfet_01v8__keta_diff_1}
++ dwg = 0.0
++ dwb = 0.0
++ pclm = {0.137157029957607+sky130_fd_pr__special_nfet_01v8__pclm_diff_1}
++ pdiblc1 = 0.35697215
++ pdiblc2 = 0.0084061121
++ pdiblcb = -0.10329577
++ drout = 0.50332666
++ pscbe1 = 791419880.0
++ pscbe2 = 1.0e-12
++ pvag = 0.0
++ delta = 0.01
++ fprout = 0.0
++ pdits = {0.0+sky130_fd_pr__special_nfet_01v8__pdits_diff_1}
++ pditsl = 0.0
++ pditsd = {0.0+sky130_fd_pr__special_nfet_01v8__pditsd_diff_1}
++ lambda = 0.0
++ lc = 5.0e-9
+* Parameters FOR Asymmetric AND Bias-Dependent RDS Model
++ rdsw = {65.968+sky130_fd_pr__special_nfet_01v8__rdsw_diff_1}
++ rsw = 0.0
++ rdw = 0.0
++ rdswmin = 0.0
++ rdwmin = 0.0
++ rswmin = 0.0
++ prwb = 0.0
++ prwg = 0.021507
++ wr = 1.0
+* Impact Ionization Current Model Parameters
++ alpha0 = 2.99999998381496e-8
++ alpha1 = 0.85
++ beta0 = 13.8499999988803
+* Gidl Induced Drain Leakage Model Parameters
++ agidl = 0.0
++ bgidl = 2300000000.0
++ cgidl = 0.5
++ egidl = 0.8
+* Gate Dielectric Tunneling Current Model Parameters
++ toxref = 4.148e-9
++ dlcig = 0.0
++ aigbacc = 1.0
++ bigbacc = 0.0
++ cigbacc = 0.0
++ nigbacc = 0.0
++ aigbinv = 0.35
++ bigbinv = 0.03
++ cigbinv = 0.006
++ eigbinv = 1.1
++ nigbinv = 0.0
++ aigc = 0.43
++ bigc = 0.054
++ cigc = 0.075
++ aigsd = 0.43
++ bigsd = 0.054
++ cigsd = 0.075
++ nigc = 0.0
++ poxedge = 1.0
++ pigcd = 1.0
++ ntox = 1.0
++ vfbsdoff = 0.0
+* Charge AND Capacitance Model Parameters
++ dlc = {1.0494e-08+sky130_fd_pr__special_nfet_01v8__dlc_diff+sky130_fd_pr__special_nfet_01v8__dlc_rotweak}
++ dwc = {0.0+sky130_fd_pr__special_nfet_01v8__dwc_diff}
++ xpart = 0.0
++ cgso = {2.54e-10*sky130_fd_pr__special_nfet_01v8__overlap_mult}
++ cgdo = {2.54e-10*sky130_fd_pr__special_nfet_01v8__overlap_mult}
++ cgbo = 1.0e-13
++ cgdl = {0.0*sky130_fd_pr__special_nfet_01v8__overlap_mult}
++ cgsl = {0.0*sky130_fd_pr__special_nfet_01v8__overlap_mult}
++ clc = 1.0e-7
++ cle = 0.6
++ cf = 1.4067e-12
++ ckappas = 0.6
++ vfbcv = -1.0
++ acde = 0.4
++ moin = 6.9
++ noff = 3.4037
++ voffcv = -0.17287
+* High-Speed/RF Model Parameters
++ xrcrg1 = 12.0
++ xrcrg2 = 1.0
++ rbpb = 50.0
++ rbpd = 50.0
++ rbps = 50.0
++ rbdb = 50.0
++ rbsb = 50.0
++ gbmin = 1.0e-12
+* Flicker AND Thermal Noise Model Parameters
++ ef = 0.84
++ noia = 2.5e+42
++ noib = 0.0
++ noic = 0.0
++ em = 41000000.0
++ ntnoi = 1.0
++ lintnoi = -1.0e-7
++ af = 1.0
++ kf = 0.0
++ tnoia = 15000000.0
++ tnoib = 9900000.0
++ rnoia = 0.94
++ rnoib = 0.26
+* Layout-Dependent Parasitics Model Parameters
++ xl = 0.0
++ xw = 0.0
++ dmcg = 0.0
++ dmdg = 0.0
++ dmcgt = 0.0
++ xgw = 0.0
++ xgl = 0.0
++ ngcon = 1.0
+* Asymmetric Source/Drain Junction Diode Model Parameters
++ jss = 0.00275
++ jsws = 6.0e-10
++ ijthsfwd = 0.1
++ ijthsrev = 0.1
++ bvs = 11.7
++ xjbvs = 1.0
++ pbs = 0.729
++ cjs = {0.0013459*sky130_fd_pr__special_nfet_01v8__ajunction_mult}
++ mjs = 0.44
++ pbsws = 0.2
++ cjsws = {3.6001e-11*sky130_fd_pr__special_nfet_01v8__pjunction_mult}
++ mjsws = 0.0009
++ pbswgs = 0.95578
++ cjswgs = {2.3347e-10*sky130_fd_pr__special_nfet_01v8__pjunction_mult}
++ mjswgs = 0.8
+* Temperature Dependence Parameters
++ tnom = 30.0
++ kt1 = {-0.240960739944239+sky130_fd_pr__special_nfet_01v8__kt1_diff_1}
++ kt2 = -0.028878939
++ at = 53720.4870179085
++ ute = -1.20689692868465
++ ua1 = -2.3847336e-11
++ ub1 = 7.0775317e-19
++ uc1 = 1.4718625e-10
++ kt1l = 0.0
++ prt = 0.0
++ tvoff = {0.0+sky130_fd_pr__special_nfet_01v8__tvoff_diff_1}
++ njs = 1.2928
++ tpb = 0.0012287
++ tcj = 0.000792
++ tpbsw = 0.0
++ tcjsw = 1.0e-5
++ tpbswg = 0.0
++ tcjswg = 0.0
++ xtis = 2.0
++ tvfbsdoff = 0.0
+* DW AND DL Parameters
++ ll = 0.0
++ wl = 0.0
++ lln = 1.0
++ wln = 1.0
++ lw = 0.0
++ ww = 0.0
++ lwn = 1.0
++ wwn = 1.0
++ lwl = 0.0
++ wwl = 0.0
++ llc = 0.0
++ wlc = 0.0
++ lwc = 0.0
++ wwc = 0.0
++ lwlc = 0.0
++ wwlc = 0.0
+* Stress Parameters
++ saref = 1.04e-6
++ sbref = 1.04e-6
++ kvth0 = 9.8e-9
++ lkvth0 = 0.0
++ wkvth0 = 2.0e-7
++ pkvth0 = 0.0
++ llodvth = 0.0
++ wlodvth = 1.0
++ wlod = 0.0
++ stk2 = 0.0
++ lodk2 = 1.0
++ lodeta0 = 1.0
++ ku0 = -2.7e-8
++ lku0 = 0.0
++ wku0 = 0.0
++ pku0 = 0.0
++ tku0 = 0.0
++ llodku0 = 0.0
++ wlodku0 = 1.0
++ kvsat = 0.2
++ steta0 = 0.0
+* Well Proximity Effect Parameters
+.ends sky130_fd_pr__special_nfet_01v8

--- a/cells/special_nfet_01v8/sky130_fd_pr__special_nfet_01v8__ff.corner.spice
+++ b/cells/special_nfet_01v8/sky130_fd_pr__special_nfet_01v8__ff.corner.spice
@@ -1,0 +1,72 @@
+* Copyright 2020 The SkyWater PDK Authors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+
+* SKY130 Spice File.
+* Number of bins: 2
+.param
++ sky130_fd_pr__special_nfet_01v8__toxe_mult = 0.9635
++ sky130_fd_pr__special_nfet_01v8__rshn_mult = 1.0
++ sky130_fd_pr__special_nfet_01v8__overlap_mult = 0.95013
++ sky130_fd_pr__special_nfet_01v8__lint_diff = 1.21275e-8
++ sky130_fd_pr__special_nfet_01v8__wint_diff = -2.252e-8
++ sky130_fd_pr__special_nfet_01v8__dlc_diff = 8.0874e-9
++ sky130_fd_pr__special_nfet_01v8__dwc_diff = -2.252e-8
+*
+* sky130_fd_pr__special_nfet_01v8, Bin 000, W = 0.36, L = 0.15
+* -----------------------------------
++ sky130_fd_pr__special_nfet_01v8__ub_diff_0 = -9.88831e-19
++ sky130_fd_pr__special_nfet_01v8__eta0_diff_0 = 2.39904e-5
++ sky130_fd_pr__special_nfet_01v8__tvoff_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__rdsw_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__a0_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__vsat_diff_0 = -41493.0
++ sky130_fd_pr__special_nfet_01v8__kt1_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__vth0_diff_0 = -0.12103
++ sky130_fd_pr__special_nfet_01v8__pdits_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__b0_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__b1_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__voff_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__pditsd_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__pclm_diff_0 = 0.0006774
++ sky130_fd_pr__special_nfet_01v8__u0_diff_0 = -0.017441
++ sky130_fd_pr__special_nfet_01v8__nfactor_diff_0 = 0.32359691
++ sky130_fd_pr__special_nfet_01v8__keta_diff_0 = 0.00226031
++ sky130_fd_pr__special_nfet_01v8__ags_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__k2_diff_0 = 0.029744
++ sky130_fd_pr__special_nfet_01v8__ua_diff_0 = -1.6427e-12
+*
+* sky130_fd_pr__special_nfet_01v8, Bin 001, W = 0.39, L = 0.15
+* -----------------------------------
++ sky130_fd_pr__special_nfet_01v8__ua_diff_1 = 2.59392e-12
++ sky130_fd_pr__special_nfet_01v8__ub_diff_1 = -8.07338e-19
++ sky130_fd_pr__special_nfet_01v8__eta0_diff_1 = 8.51883e-6
++ sky130_fd_pr__special_nfet_01v8__tvoff_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__a0_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__rdsw_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__vsat_diff_1 = -39855.0
++ sky130_fd_pr__special_nfet_01v8__kt1_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__vth0_diff_1 = -0.12287
++ sky130_fd_pr__special_nfet_01v8__pdits_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__b0_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__b1_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__voff_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__pditsd_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__pclm_diff_1 = 0.00024054
++ sky130_fd_pr__special_nfet_01v8__u0_diff_1 = -0.014549
++ sky130_fd_pr__special_nfet_01v8__nfactor_diff_1 = 0.32663125
++ sky130_fd_pr__special_nfet_01v8__keta_diff_1 = 0.00080262
++ sky130_fd_pr__special_nfet_01v8__ags_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__k2_diff_1 = 0.029369
+*
+.include "sky130_fd_pr__special_nfet_01v8__ff.pm3.spice"

--- a/cells/special_nfet_01v8/sky130_fd_pr__special_nfet_01v8__ff.pm3.spice
+++ b/cells/special_nfet_01v8/sky130_fd_pr__special_nfet_01v8__ff.pm3.spice
@@ -1,0 +1,574 @@
+* Copyright 2020 The SkyWater PDK Authors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+
+* SKY130 Spice File.
+.param sky130_fd_pr__special_nfet_01v8__toxe_slope_spectre = 0.0
+.param sky130_fd_pr__special_nfet_01v8__vth0_slope_spectre = 0.0
+.param sky130_fd_pr__special_nfet_01v8__voff_slope_spectre = 0.0
+* statistics {
+*   process {
+*   }
+*   mismatch {
+*     vary sky130_fd_pr__special_nfet_01v8__toxe_slope_spectre dist=gauss std = 1.0
+*     vary sky130_fd_pr__special_nfet_01v8__vth0_slope_spectre dist=gauss std = 1.0
+*     vary sky130_fd_pr__special_nfet_01v8__voff_slope_spectre dist=gauss std = 1.0
+*   }
+* }
+.subckt  sky130_fd_pr__special_nfet_01v8 d g s b
++ 
+.param  l = 1 w = 1 nf = 1.0 ad = 0 as = 0 pd = 0 ps = 0 nrd = 0 nrs = 0 sa = 0 sb = 0 sd = 0 mult = 1
+msky130_fd_pr__special_nfet_01v8 d g s b sky130_fd_pr__special_nfet_01v8__model l = {l} w = {w} nf = {nf} ad = {ad} as = {as} pd = {pd} ps = {ps} nrd = {nrd} nrs = {nrs} sa = {sa} sb = {sb} sd = {sd}
+.model sky130_fd_pr__special_nfet_01v8__model.0 nmos
+* Model Flag Parameters
++ lmin = 1.5e-07 lmax = 1.8e-07 wmin = 3.9e-07 wmax = 4.2e-7
++ level = 54.0
++ version = 4.5
++ binunit = 2.0
++ mobmod = 0.0
++ capmod = 2.0
++ igcmod = 0.0
++ igbmod = 0.0
++ geomod = 0.0
++ diomod = 1.0
++ rdsmod = 0.0
++ rbodymod = 1.0
++ rgatemod = 0.0
++ permod = 1.0
++ acnqsmod = 0.0
++ trnqsmod = 0.0
++ fnoimod = 1.0
++ tnoimod = 1.0
++ tempmod = 0.0
+* Process Parameters
+*(mismatch parameter sky130_fd_pr__special_nfet_01v8__toxe_slope_spectre)
++ toxe = {3.996598e-09+MC_MM_SWITCH*AGAUSS(0,1.0,1)*(4.148e-9*0.9635*(sky130_fd_pr__special_nfet_01v8__toxe_slope/sqrt(l*w*mult)))}
++ toxm = 4.148e-9
++ dtox = 0.0
++ epsrox = 3.9
++ xj = 1.5e-7
++ ngate = 1.0e+23
++ ndep = 1.7e+17
++ nsd = 1.0e+20
++ rsh = 1.0
++ rshg = 0.1
+* Basic Model Parameters
++ wint = -6.60999999999998e-10
++ lint = 2.40595e-8
+*(mismatch parameter sky130_fd_pr__special_nfet_01v8__vth0_slope_spectre)
++ vth0 = {-2.522595364e+00+MC_MM_SWITCH*AGAUSS(0,1.0,1)*(sky130_fd_pr__special_nfet_01v8__vth0_slope/sqrt(l*w*mult))} lvth0 = 3.827378328e-07 wvth0 = 1.366349450e-06 pvth0 = -1.801955318e-13
++ k1 = 0.90707349
++ k2 = -1.214234996e+00 lk2 = 1.428322922e-07 wk2 = 4.202331718e-07 pk2 = -5.542077093e-14
++ k3 = 2.0
++ k3b = 0.54
++ w0 = 0.0
++ dvt0 = 0.0
++ dvt1 = 0.53
++ dvt2 = -0.032
++ dvt0w = -3.58
++ dvt1w = 1670600.0
++ dvt2w = 0.068
++ dsub = 3.091390987e+00 ldsub = -3.254375986e-07 wdsub = -1.039679862e-06 pdsub = 1.371140199e-13
++ minv = 0.0
++ voffl = 5.8197729e-9
++ lpe0 = 1.0325e-7
++ lpeb = -7.082e-8
++ vbm = -3.0
++ dvtp0 = 0.0
++ dvtp1 = 0.0
++ phin = 0.0
++ cdsc = 0.0
++ cdscb = 0.0
++ cdscd = 0.002052
++ cit = 0.0
+*(mismatch parameter sky130_fd_pr__special_nfet_01v8__voff_slope_spectre)
++ voff = {-0.20753+MC_MM_SWITCH*AGAUSS(0,1.0,1)*(sky130_fd_pr__special_nfet_01v8__voff_slope/sqrt(l*w*mult))}
++ nfactor = -5.755837948e+00 lnfactor = 1.003645791e-06 wnfactor = 2.035947004e-06 pnfactor = -2.685027268e-13
++ eta0 = 3.773678949e-04 leta0 = -4.976765037e-11 weta0 = -1.589933803e-10 peta0 = 2.096820599e-17
++ etab = -0.043998
++ u0 = 1.180195927e-01 lu0 = -1.220162915e-08 wu0 = -3.513079141e-08 pu0 = 4.633083902e-15
++ ua = -1.561180192e-09 lua = 5.276323956e-17 wua = 2.136372329e-16 pua = -2.817469192e-23
++ ub = 3.405756539e-18 lub = -1.493837899e-25 wub = -2.026061243e-25 pub = 2.671989827e-32
++ uc = -1.174583905e-10 luc = 2.755223438e-17 wuc = 1.212251842e-16 puc = -1.598729852e-23
++ ud = 0.0
++ up = 0.0
++ lp = 1.0
++ eu = 1.67
++ vtl = 0.0
++ xn = 3.0
++ vsat = 5.803855899e+05 lvsat = -5.641270307e-02 wvsat = -1.776827075e-01 pvsat = 2.343297315e-8
++ a0 = 1.5
++ ags = 1.25
++ a1 = 0.0
++ a2 = 0.42385546
++ b0 = 0.0
++ b1 = 0.0
++ keta = -9.287045780e-01 lketa = 1.134609932e-07 wketa = 3.968494623e-07 pketa = -5.233690393e-14
++ dwg = 0.0
++ dwb = 0.0
++ pclm = 2.580727704e-02 lpclm = 2.048675365e-08 wpclm = 1.189334913e-07 ppclm = -1.568506776e-14
++ pdiblc1 = 0.35697215
++ pdiblc2 = 0.0084061121
++ pdiblcb = -0.10329577
++ drout = 0.50332666
++ pscbe1 = 791419880.0
++ pscbe2 = 1.0e-12
++ pvag = 0.0
++ delta = 0.01
++ fprout = 0.0
++ pdits = 0.0
++ pditsl = 0.0
++ pditsd = 0.0
++ lambda = 0.0
++ lc = 5.0e-9
+* Parameters FOR Asymmetric AND Bias-Dependent RDS Model
++ rdsw = 65.968
++ rsw = 0.0
++ rdw = 0.0
++ rdswmin = 0.0
++ rdwmin = 0.0
++ rswmin = 0.0
++ prwb = 0.0
++ prwg = 0.021507
++ wr = 1.0
+* Impact Ionization Current Model Parameters
++ alpha0 = 1.249543128e-07 lalpha0 = -9.674040130e-15 walpha0 = 3.020736542e-21 palpha0 = -3.983777534e-28
++ alpha1 = 0.85
++ beta0 = 1.626781828e+01 lbeta0 = -2.463297431e-07 wbeta0 = 2.089785767e-14 pbeta0 = -2.756024742e-21
+* Gidl Induced Drain Leakage Model Parameters
++ agidl = 0.0
++ bgidl = 2300000000.0
++ cgidl = 0.5
++ egidl = 0.8
+* Gate Dielectric Tunneling Current Model Parameters
++ toxref = 4.148e-9
++ dlcig = 0.0
++ aigbacc = 1.0
++ bigbacc = 0.0
++ cigbacc = 0.0
++ nigbacc = 0.0
++ aigbinv = 0.35
++ bigbinv = 0.03
++ cigbinv = 0.006
++ eigbinv = 1.1
++ nigbinv = 0.0
++ aigc = 0.43
++ bigc = 0.054
++ cigc = 0.075
++ aigsd = 0.43
++ bigsd = 0.054
++ cigsd = 0.075
++ nigc = 0.0
++ poxedge = 1.0
++ pigcd = 1.0
++ ntox = 1.0
++ vfbsdoff = 0.0
+* Charge AND Capacitance Model Parameters
++ dlc = 1.85814e-8
++ dwc = -2.252e-8
++ xpart = 0.0
++ cgso = 2.4133302e-10
++ cgdo = 2.4133302e-10
++ cgbo = 1.0e-13
++ cgdl = 0.0
++ cgsl = 0.0
++ clc = 1.0e-7
++ cle = 0.6
++ cf = 1.4067e-12
++ ckappas = 0.6
++ vfbcv = -1.0
++ acde = 0.4
++ moin = 6.9
++ noff = 3.4037
++ voffcv = -0.17287
+* High-Speed/RF Model Parameters
++ xrcrg1 = 12.0
++ xrcrg2 = 1.0
++ rbpb = 50.0
++ rbpd = 50.0
++ rbps = 50.0
++ rbdb = 50.0
++ rbsb = 50.0
++ gbmin = 1.0e-12
+* Flicker AND Thermal Noise Model Parameters
++ ef = 0.84
++ noia = 2.5e+42
++ noib = 0.0
++ noic = 0.0
++ em = 41000000.0
++ ntnoi = 1.0
++ lintnoi = -1.0e-7
++ af = 1.0
++ kf = 0.0
++ tnoia = 15000000.0
++ tnoib = 9900000.0
++ rnoia = 0.94
++ rnoib = 0.26
+* Layout-Dependent Parasitics Model Parameters
++ xl = 0.0
++ xw = 0.0
++ dmcg = 0.0
++ dmdg = 0.0
++ dmcgt = 0.0
++ xgw = 0.0
++ xgl = 0.0
++ ngcon = 1.0
+* Asymmetric Source/Drain Junction Diode Model Parameters
++ jss = 0.00275
++ jsws = 6.0e-10
++ ijthsfwd = 0.1
++ ijthsrev = 0.1
++ bvs = 11.7
++ xjbvs = 1.0
++ pbs = 0.729
++ cjs = 0.001131080901
++ mjs = 0.44
++ pbsws = 0.2
++ cjsws = 3.101378147e-11
++ mjsws = 0.0009
++ pbswgs = 0.95578
++ cjswgs = 2.011274009e-10
++ mjswgs = 0.8
+* Temperature Dependence Parameters
++ tnom = 30.0
++ kt1 = -1.530400709e-01 lkt1 = -8.957445766e-09 wkt1 = -1.040710629e-15 pkt1 = 1.372498781e-22
++ kt2 = -0.028878939
++ at = 9.760154460e+03 lat = 4.478722616e-03 wat = -3.342397977e-10 pat = 4.407987581e-17
++ ute = -9.447486384e-01 lute = -4.408710108e-08 wute = -2.266950667e-07 pute = 2.989677209e-14
++ ua1 = -2.3847336e-11
++ ub1 = 7.0775317e-19
++ uc1 = 1.4718625e-10
++ kt1l = 0.0
++ prt = 0.0
++ tvoff = 0.0
++ njs = 1.2928
++ tpb = 0.0012287
++ tcj = 0.000792
++ tpbsw = 0.0
++ tcjsw = 1.0e-5
++ tpbswg = 0.0
++ tcjswg = 0.0
++ xtis = 2.0
++ tvfbsdoff = 0.0
+* DW AND DL Parameters
++ ll = 0.0
++ wl = 0.0
++ lln = 1.0
++ wln = 1.0
++ lw = 0.0
++ ww = 0.0
++ lwn = 1.0
++ wwn = 1.0
++ lwl = 0.0
++ wwl = 0.0
++ llc = 0.0
++ wlc = 0.0
++ lwc = 0.0
++ wwc = 0.0
++ lwlc = 0.0
++ wwlc = 0.0
+* Stress Parameters
++ saref = 1.04e-6
++ sbref = 1.04e-6
++ kvth0 = 9.8e-9
++ lkvth0 = 0.0
++ wkvth0 = 2.0e-7
++ pkvth0 = 0.0
++ llodvth = 0.0
++ wlodvth = 1.0
++ wlod = 0.0
++ stk2 = 0.0
++ lodk2 = 1.0
++ lodeta0 = 1.0
++ ku0 = -2.7e-8
++ lku0 = 0.0
++ wku0 = 0.0
++ pku0 = 0.0
++ tku0 = 0.0
++ llodku0 = 0.0
++ wlodku0 = 1.0
++ kvsat = 0.2
++ steta0 = 0.0
+* Well Proximity Effect Parameters
+.model sky130_fd_pr__special_nfet_01v8__model.1 nmos
+* Model Flag Parameters
++ lmin = 1.5e-07 lmax = 1.8e-07 wmin = 3.6e-07 wmax = 3.9e-7
++ level = 54.0
++ version = 4.5
++ binunit = 2.0
++ mobmod = 0.0
++ capmod = 2.0
++ igcmod = 0.0
++ igbmod = 0.0
++ geomod = 0.0
++ diomod = 1.0
++ rdsmod = 0.0
++ rbodymod = 1.0
++ rgatemod = 0.0
++ permod = 1.0
++ acnqsmod = 0.0
++ trnqsmod = 0.0
++ fnoimod = 1.0
++ tnoimod = 1.0
++ tempmod = 0.0
+* Process Parameters
+*(mismatch parameter sky130_fd_pr__special_nfet_01v8__toxe_slope_spectre)
++ toxe = {3.996598e-09+MC_MM_SWITCH*AGAUSS(0,1.0,1)*(4.148e-9*0.9635*(sky130_fd_pr__special_nfet_01v8__toxe_slope/sqrt(l*w*mult)))}
++ toxm = 4.148e-9
++ dtox = 0.0
++ epsrox = 3.9
++ xj = 1.5e-7
++ ngate = 1.0e+23
++ ndep = 1.7e+17
++ nsd = 1.0e+20
++ rsh = 1.0
++ rshg = 0.1
+* Basic Model Parameters
++ wint = -6.60999999999998e-10
++ lint = 2.40595e-8
+*(mismatch parameter sky130_fd_pr__special_nfet_01v8__vth0_slope_spectre)
++ vth0 = {-3.719569900e-01+MC_MM_SWITCH*AGAUSS(0,1.0,1)*(sky130_fd_pr__special_nfet_01v8__vth0_slope/sqrt(l*w*mult))} lvth0 = 9.910949335e-08 wvth0 = 5.247573396e-07 pvth0 = -6.920552270e-14
++ k1 = 0.90707349
++ k2 = -4.158704441e-01 lk2 = 3.754317674e-08 wk2 = 1.078155588e-07 pk2 = -1.421882371e-14
++ k3 = 2.0
++ k3b = 0.54
++ w0 = 0.0
++ dvt0 = 0.0
++ dvt1 = 0.53
++ dvt2 = -0.032
++ dvt0w = -3.58
++ dvt1w = 1670600.0
++ dvt2w = 0.068
++ dsub = 3.145270833e+00 ldsub = -3.325433265e-07 wdsub = -1.060764231e-06 pdsub = 1.398946476e-13
++ minv = 0.0
++ voffl = 5.8197729e-9
++ lpe0 = 1.0325e-7
++ lpeb = -7.082e-8
++ vbm = -3.0
++ dvtp0 = 0.0
++ dvtp1 = 0.0
++ phin = 0.0
++ cdsc = 0.0
++ cdscb = 0.0
++ cdscd = 0.002052
++ cit = 0.0
+*(mismatch parameter sky130_fd_pr__special_nfet_01v8__voff_slope_spectre)
++ voff = {-0.20753+MC_MM_SWITCH*AGAUSS(0,1.0,1)*(sky130_fd_pr__special_nfet_01v8__voff_slope/sqrt(l*w*mult))}
++ nfactor = -5.755837763e+00 lnfactor = 1.003645766e-06 wnfactor = 2.035946931e-06 pnfactor = -2.685027173e-13
++ eta0 = 6.038887884e-04 leta0 = -7.964144934e-11 weta0 = -2.476359805e-10 peta0 = 3.265848075e-17
++ etab = -0.043998
++ u0 = 2.605260337e-02 lu0 = -7.293063698e-11 wu0 = 8.579147789e-10 pu0 = -1.131426590e-16
++ ua = -1.561180684e-09 lua = 5.276330447e-17 wua = 2.136374256e-16 pua = -2.817471732e-23
++ ub = 3.405791239e-18 lub = -1.493883661e-25 wub = -2.026197031e-25 pub = 2.672168906e-32
++ uc = -1.237407073e-10 luc = 2.838075260e-17 wuc = 1.236835930e-16 puc = -1.631151593e-23
++ ud = 0.0
++ up = 0.0
++ lp = 1.0
++ eu = 1.67
++ vtl = 0.0
++ xn = 3.0
++ vsat = 2.566624309e+05 lvsat = -1.371976914e-02 wvsat = -5.100271349e-02 pvsat = 6.726288858e-9
++ a0 = 1.5
++ ags = 1.25
++ a1 = 0.0
++ a2 = 0.42385546
++ b0 = 0.0
++ b1 = 0.0
++ keta = -9.287047565e-01 lketa = 1.134610167e-07 wketa = 3.968495321e-07 pketa = -5.233691314e-14
++ dwg = 0.0
++ dwb = 0.0
++ pclm = 2.580720676e-02 lpclm = 2.048676292e-08 wpclm = 1.189335188e-07 ppclm = -1.568507139e-14
++ pdiblc1 = 0.35697215
++ pdiblc2 = 0.0084061121
++ pdiblcb = -0.10329577
++ drout = 0.50332666
++ pscbe1 = 791419880.0
++ pscbe2 = 1.0e-12
++ pvag = 0.0
++ delta = 0.01
++ fprout = 0.0
++ pdits = 0.0
++ pditsl = 0.0
++ pditsd = 0.0
++ lambda = 0.0
++ lc = 5.0e-9
+* Parameters FOR Asymmetric AND Bias-Dependent RDS Model
++ rdsw = 65.968
++ rsw = 0.0
++ rdw = 0.0
++ rdswmin = 0.0
++ rdwmin = 0.0
++ rswmin = 0.0
++ prwb = 0.0
++ prwg = 0.021507
++ wr = 1.0
+* Impact Ionization Current Model Parameters
++ alpha0 = 1.249543200e-07 lalpha0 = -9.674041071e-15 walpha0 = 2.285430417e-22 palpha0 = -3.014048952e-29
++ alpha1 = 0.85
++ beta0 = 1.626781834e+01 lbeta0 = -2.463297501e-07 wbeta0 = 4.001776688e-17 pbeta0 = -5.275779813e-24
+* Gidl Induced Drain Leakage Model Parameters
++ agidl = 0.0
++ bgidl = 2300000000.0
++ cgidl = 0.5
++ egidl = 0.8
+* Gate Dielectric Tunneling Current Model Parameters
++ toxref = 4.148e-9
++ dlcig = 0.0
++ aigbacc = 1.0
++ bigbacc = 0.0
++ cigbacc = 0.0
++ nigbacc = 0.0
++ aigbinv = 0.35
++ bigbinv = 0.03
++ cigbinv = 0.006
++ eigbinv = 1.1
++ nigbinv = 0.0
++ aigc = 0.43
++ bigc = 0.054
++ cigc = 0.075
++ aigsd = 0.43
++ bigsd = 0.054
++ cigsd = 0.075
++ nigc = 0.0
++ poxedge = 1.0
++ pigcd = 1.0
++ ntox = 1.0
++ vfbsdoff = 0.0
+* Charge AND Capacitance Model Parameters
++ dlc = 1.85814e-8
++ dwc = -2.252e-8
++ xpart = 0.0
++ cgso = 2.4133302e-10
++ cgdo = 2.4133302e-10
++ cgbo = 1.0e-13
++ cgdl = 0.0
++ cgsl = 0.0
++ clc = 1.0e-7
++ cle = 0.6
++ cf = 1.4067e-12
++ ckappas = 0.6
++ vfbcv = -1.0
++ acde = 0.4
++ moin = 6.9
++ noff = 3.4037
++ voffcv = -0.17287
+* High-Speed/RF Model Parameters
++ xrcrg1 = 12.0
++ xrcrg2 = 1.0
++ rbpb = 50.0
++ rbpd = 50.0
++ rbps = 50.0
++ rbdb = 50.0
++ rbsb = 50.0
++ gbmin = 1.0e-12
+* Flicker AND Thermal Noise Model Parameters
++ ef = 0.84
++ noia = 2.5e+42
++ noib = 0.0
++ noic = 0.0
++ em = 41000000.0
++ ntnoi = 1.0
++ lintnoi = -1.0e-7
++ af = 1.0
++ kf = 0.0
++ tnoia = 15000000.0
++ tnoib = 9900000.0
++ rnoia = 0.94
++ rnoib = 0.26
+* Layout-Dependent Parasitics Model Parameters
++ xl = 0.0
++ xw = 0.0
++ dmcg = 0.0
++ dmdg = 0.0
++ dmcgt = 0.0
++ xgw = 0.0
++ xgl = 0.0
++ ngcon = 1.0
+* Asymmetric Source/Drain Junction Diode Model Parameters
++ jss = 0.00275
++ jsws = 6.0e-10
++ ijthsfwd = 0.1
++ ijthsrev = 0.1
++ bvs = 11.7
++ xjbvs = 1.0
++ pbs = 0.729
++ cjs = 0.001131080901
++ mjs = 0.44
++ pbsws = 0.2
++ cjsws = 3.101378147e-11
++ mjsws = 0.0009
++ pbswgs = 0.95578
++ cjswgs = 2.011274009e-10
++ mjswgs = 0.8
+* Temperature Dependence Parameters
++ tnom = 30.0
++ kt1 = -1.530400733e-01 lkt1 = -8.957445444e-09 wkt1 = -8.505551818e-17 pkt1 = 1.121713833e-23
++ kt2 = -0.028878939
++ at = 9.760153675e+03 lat = 4.478722719e-03 wat = -2.698588651e-11 pat = 3.558932804e-18
++ ute = -9.330005132e-01 lute = -4.563645557e-08 wute = -2.312923665e-07 pute = 3.050306858e-14
++ ua1 = -2.3847336e-11
++ ub1 = 7.0775317e-19
++ uc1 = 1.4718625e-10
++ kt1l = 0.0
++ prt = 0.0
++ tvoff = 0.0
++ njs = 1.2928
++ tpb = 0.0012287
++ tcj = 0.000792
++ tpbsw = 0.0
++ tcjsw = 1.0e-5
++ tpbswg = 0.0
++ tcjswg = 0.0
++ xtis = 2.0
++ tvfbsdoff = 0.0
+* DW AND DL Parameters
++ ll = 0.0
++ wl = 0.0
++ lln = 1.0
++ wln = 1.0
++ lw = 0.0
++ ww = 0.0
++ lwn = 1.0
++ wwn = 1.0
++ lwl = 0.0
++ wwl = 0.0
++ llc = 0.0
++ wlc = 0.0
++ lwc = 0.0
++ wwc = 0.0
++ lwlc = 0.0
++ wwlc = 0.0
+* Stress Parameters
++ saref = 1.04e-6
++ sbref = 1.04e-6
++ kvth0 = 9.8e-9
++ lkvth0 = 0.0
++ wkvth0 = 2.0e-7
++ pkvth0 = 0.0
++ llodvth = 0.0
++ wlodvth = 1.0
++ wlod = 0.0
++ stk2 = 0.0
++ lodk2 = 1.0
++ lodeta0 = 1.0
++ ku0 = -2.7e-8
++ lku0 = 0.0
++ wku0 = 0.0
++ pku0 = 0.0
++ tku0 = 0.0
++ llodku0 = 0.0
++ wlodku0 = 1.0
++ kvsat = 0.2
++ steta0 = 0.0
+.ends sky130_fd_pr__special_nfet_01v8
+* Well Proximity Effect Parameters

--- a/cells/special_nfet_01v8/sky130_fd_pr__special_nfet_01v8__fs.corner.spice
+++ b/cells/special_nfet_01v8/sky130_fd_pr__special_nfet_01v8__fs.corner.spice
@@ -1,0 +1,72 @@
+* Copyright 2020 The SkyWater PDK Authors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+
+* SKY130 Spice File.
+* Number of bins: 2
+.param
++ sky130_fd_pr__special_nfet_01v8__toxe_mult = 1.052
++ sky130_fd_pr__special_nfet_01v8__rshn_mult = 1.0
++ sky130_fd_pr__special_nfet_01v8__overlap_mult = 0.96
++ sky130_fd_pr__special_nfet_01v8__lint_diff = -1.7325e-8
++ sky130_fd_pr__special_nfet_01v8__wint_diff = 3.2175e-8
++ sky130_fd_pr__special_nfet_01v8__dlc_diff = -17.422e-9
++ sky130_fd_pr__special_nfet_01v8__dwc_diff = 3.2175e-8
+*
+* sky130_fd_pr__special_nfet_01v8, Bin 000, W = 0.36, L = 0.15
+* -----------------------------------
++ sky130_fd_pr__special_nfet_01v8__ub_diff_0 = -9.25732e-19
++ sky130_fd_pr__special_nfet_01v8__eta0_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__tvoff_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__rdsw_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__a0_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__vsat_diff_0 = 61290.0
++ sky130_fd_pr__special_nfet_01v8__kt1_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__vth0_diff_0 = 0.20231
++ sky130_fd_pr__special_nfet_01v8__pdits_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__b0_diff_0 = -3.83749e-7
++ sky130_fd_pr__special_nfet_01v8__b1_diff_0 = 5.35706e-7
++ sky130_fd_pr__special_nfet_01v8__voff_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__pditsd_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__pclm_diff_0 = -0.00138806
++ sky130_fd_pr__special_nfet_01v8__u0_diff_0 = -0.0055061
++ sky130_fd_pr__special_nfet_01v8__nfactor_diff_0 = -0.28553522
++ sky130_fd_pr__special_nfet_01v8__keta_diff_0 = -0.00463159
++ sky130_fd_pr__special_nfet_01v8__ags_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__k2_diff_0 = 0.0033146
++ sky130_fd_pr__special_nfet_01v8__ua_diff_0 = 1.1629e-11
+*
+* sky130_fd_pr__special_nfet_01v8, Bin 001, W = 0.39, L = 0.15
+* -----------------------------------
++ sky130_fd_pr__special_nfet_01v8__ua_diff_1 = 1.29918e-11
++ sky130_fd_pr__special_nfet_01v8__ub_diff_1 = -6.92044e-19
++ sky130_fd_pr__special_nfet_01v8__eta0_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__tvoff_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__a0_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__rdsw_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__vsat_diff_1 = 56521.0
++ sky130_fd_pr__special_nfet_01v8__kt1_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__vth0_diff_1 = 0.19124
++ sky130_fd_pr__special_nfet_01v8__pdits_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__b0_diff_1 = -4.12472e-7
++ sky130_fd_pr__special_nfet_01v8__b1_diff_1 = 4.27529e-7
++ sky130_fd_pr__special_nfet_01v8__voff_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__pditsd_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__pclm_diff_1 = -0.00047701
++ sky130_fd_pr__special_nfet_01v8__u0_diff_1 = -0.0036776
++ sky130_fd_pr__special_nfet_01v8__nfactor_diff_1 = -0.28192852
++ sky130_fd_pr__special_nfet_01v8__keta_diff_1 = -0.00159166
++ sky130_fd_pr__special_nfet_01v8__ags_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__k2_diff_1 = -0.0017464
+*
+.include "sky130_fd_pr__special_nfet_01v8__fs.pm3.spice"

--- a/cells/special_nfet_01v8/sky130_fd_pr__special_nfet_01v8__fs.pm3.spice
+++ b/cells/special_nfet_01v8/sky130_fd_pr__special_nfet_01v8__fs.pm3.spice
@@ -1,0 +1,574 @@
+* Copyright 2020 The SkyWater PDK Authors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+
+* SKY130 Spice File.
+.param sky130_fd_pr__special_nfet_01v8__toxe_slope_spectre = 0.0
+.param sky130_fd_pr__special_nfet_01v8__vth0_slope_spectre = 0.0
+.param sky130_fd_pr__special_nfet_01v8__voff_slope_spectre = 0.0
+* statistics {
+*   process {
+*   }
+*   mismatch {
+*     vary sky130_fd_pr__special_nfet_01v8__toxe_slope_spectre dist=gauss std = 1.0
+*     vary sky130_fd_pr__special_nfet_01v8__vth0_slope_spectre dist=gauss std = 1.0
+*     vary sky130_fd_pr__special_nfet_01v8__voff_slope_spectre dist=gauss std = 1.0
+*   }
+* }
+.subckt  sky130_fd_pr__special_nfet_01v8 d g s b
++ 
+.param  l = 1 w = 1 nf = 1.0 ad = 0 as = 0 pd = 0 ps = 0 nrd = 0 nrs = 0 sa = 0 sb = 0 sd = 0 mult = 1
+msky130_fd_pr__special_nfet_01v8 d g s b sky130_fd_pr__special_nfet_01v8__model l = {l} w = {w} nf = {nf} ad = {ad} as = {as} pd = {pd} ps = {ps} nrd = {nrd} nrs = {nrs} sa = {sa} sb = {sb} sd = {sd}
+.model sky130_fd_pr__special_nfet_01v8__model.0 nmos
+* Model Flag Parameters
++ lmin = 1.5e-07 lmax = 1.8e-07 wmin = 3.9e-07 wmax = 4.2e-7
++ level = 54.0
++ version = 4.5
++ binunit = 2.0
++ mobmod = 0.0
++ capmod = 2.0
++ igcmod = 0.0
++ igbmod = 0.0
++ geomod = 0.0
++ diomod = 1.0
++ rdsmod = 0.0
++ rbodymod = 1.0
++ rgatemod = 0.0
++ permod = 1.0
++ acnqsmod = 0.0
++ trnqsmod = 0.0
++ fnoimod = 1.0
++ tnoimod = 1.0
++ tempmod = 0.0
+* Process Parameters
+*(mismatch parameter sky130_fd_pr__special_nfet_01v8__toxe_slope_spectre)
++ toxe = {4.363696e-09+MC_MM_SWITCH*AGAUSS(0,1.0,1)*(4.148e-9*1.052*(sky130_fd_pr__special_nfet_01v8__toxe_slope/sqrt(l*w*mult)))}
++ toxm = 4.148e-9
++ dtox = 0.0
++ epsrox = 3.9
++ xj = 1.5e-7
++ ngate = 1.0e+23
++ ndep = 1.7e+17
++ nsd = 1.0e+20
++ rsh = 1.0
++ rshg = 0.1
+* Basic Model Parameters
++ wint = 5.4034e-8
++ lint = -5.393e-9
+*(mismatch parameter sky130_fd_pr__special_nfet_01v8__vth0_slope_spectre)
++ vth0 = {-1.307351324e-01+MC_MM_SWITCH*AGAUSS(0,1.0,1)*(sky130_fd_pr__special_nfet_01v8__vth0_slope/sqrt(l*w*mult))} lvth0 = 1.237487853e-07 wvth0 = 1.795588670e-07 pvth0 = -3.425731800e-14
++ k1 = 0.90707349
++ k2 = 9.806228507e-02 lk2 = -4.858046592e-08 wk2 = -6.719062103e-08 pk2 = 1.281902982e-14
++ k3 = 2.0
++ k3b = 0.54
++ w0 = 0.0
++ dvt0 = 0.0
++ dvt1 = 0.53
++ dvt2 = -0.032
++ dvt0w = -3.58
++ dvt1w = 1670600.0
++ dvt2w = 0.068
++ dsub = 3.429490745e+00 ldsub = -5.352998694e-07 wdsub = -8.752065606e-07 pdsub = 1.669771589e-13
++ minv = 0.0
++ voffl = 5.8197729e-9
++ lpe0 = 1.0325e-7
++ lpeb = -7.082e-8
++ vbm = -3.0
++ dvtp0 = 0.0
++ dvtp1 = 0.0
++ phin = 0.0
++ cdsc = 0.0
++ cdscb = 0.0
++ cdscd = 0.002052
++ cit = 0.0
+*(mismatch parameter sky130_fd_pr__special_nfet_01v8__voff_slope_spectre)
++ voff = {-0.20753+MC_MM_SWITCH*AGAUSS(0,1.0,1)*(sky130_fd_pr__special_nfet_01v8__voff_slope/sqrt(l*w*mult))}
++ nfactor = -1.343760374e+01 lnfactor = 2.647398761e-06 wnfactor = 1.621325400e-06 pnfactor = -3.093261878e-13
++ eta0 = 0.0
++ etab = -0.043998
++ u0 = 1.766145641e-01 lu0 = -2.968908023e-08 wu0 = -6.587716269e-08 pu0 = 1.256844036e-14
++ ua = -1.072899214e-09 lua = -5.272902601e-18 wua = 1.329021165e-16 pua = -2.535586320e-23
++ ub = -6.163090404e-18 lub = 1.399215062e-24 wub = 5.016658097e-25 pub = -9.571081316e-32
++ uc = -1.113153575e-10 luc = 3.868650857e-17 wuc = 1.020478326e-16 puc = -1.946929779e-23
++ ud = 0.0
++ up = 0.0
++ lp = 1.0
++ eu = 1.67
++ vtl = 0.0
++ xn = 3.0
++ vsat = -1.306845638e+05 lvsat = 7.311235533e-02 wvsat = 1.016641890e-01 pvsat = -1.939610396e-8
++ a0 = 1.5
++ ags = 1.25
++ a1 = 0.0
++ a2 = 0.42385546
++ b0 = 3.055917419e-06 lb0 = -5.964511084e-13 wb0 = -3.644689769e-13 pb0 = 6.953557823e-20
++ b1 = 2.309490899e-06 lb1 = -4.486574896e-13 wb1 = -1.372673939e-12 pb1 = 2.618869702e-19
++ keta = -1.131181136e+00 lketa = 2.027683406e-07 wketa = 3.716864939e-07 pketa = -7.091257942e-14
++ dwg = 0.0
++ dwb = 0.0
++ pclm = 2.438503395e-02 lpclm = 2.990856081e-08 wpclm = 1.113922654e-07 ppclm = -2.125208474e-14
++ pdiblc1 = 0.35697215
++ pdiblc2 = 0.0084061121
++ pdiblcb = -0.10329577
++ drout = 0.50332666
++ pscbe1 = 791419880.0
++ pscbe2 = 1.0e-12
++ pvag = 0.0
++ delta = 0.01
++ fprout = 0.0
++ pdits = 0.0
++ pditsl = 0.0
++ pditsd = 0.0
++ lambda = 0.0
++ lc = 5.0e-9
+* Parameters FOR Asymmetric AND Bias-Dependent RDS Model
++ rdsw = 65.968
++ rsw = 0.0
++ rdw = 0.0
++ rdswmin = 0.0
++ rdwmin = 0.0
++ rswmin = 0.0
++ prwb = 0.0
++ prwg = 0.021507
++ wr = 1.0
+* Impact Ionization Current Model Parameters
++ alpha0 = 1.673659118e-07 lalpha0 = -2.208651526e-14 walpha0 = 2.542867870e-21 palpha0 = -4.851435998e-28
++ alpha1 = 0.85
++ beta0 = 1.734774328e+01 lbeta0 = -5.623881488e-07 wbeta0 = 1.759190127e-14 pbeta0 = -3.356277034e-21
+* Gidl Induced Drain Leakage Model Parameters
++ agidl = 0.0
++ bgidl = 2300000000.0
++ cgidl = 0.5
++ egidl = 0.8
+* Gate Dielectric Tunneling Current Model Parameters
++ toxref = 4.148e-9
++ dlcig = 0.0
++ aigbacc = 1.0
++ bigbacc = 0.0
++ cigbacc = 0.0
++ nigbacc = 0.0
++ aigbinv = 0.35
++ bigbinv = 0.03
++ cigbinv = 0.006
++ eigbinv = 1.1
++ nigbinv = 0.0
++ aigc = 0.43
++ bigc = 0.054
++ cigc = 0.075
++ aigsd = 0.43
++ bigsd = 0.054
++ cigsd = 0.075
++ nigc = 0.0
++ poxedge = 1.0
++ pigcd = 1.0
++ ntox = 1.0
++ vfbsdoff = 0.0
+* Charge AND Capacitance Model Parameters
++ dlc = -6.928e-9
++ dwc = 3.2175e-8
++ xpart = 0.0
++ cgso = 2.4384e-10
++ cgdo = 2.4384e-10
++ cgbo = 1.0e-13
++ cgdl = 0.0
++ cgsl = 0.0
++ clc = 1.0e-7
++ cle = 0.6
++ cf = 1.4067e-12
++ ckappas = 0.6
++ vfbcv = -1.0
++ acde = 0.4
++ moin = 6.9
++ noff = 3.4037
++ voffcv = -0.17287
+* High-Speed/RF Model Parameters
++ xrcrg1 = 12.0
++ xrcrg2 = 1.0
++ rbpb = 50.0
++ rbpd = 50.0
++ rbps = 50.0
++ rbdb = 50.0
++ rbsb = 50.0
++ gbmin = 1.0e-12
+* Flicker AND Thermal Noise Model Parameters
++ ef = 0.84
++ noia = 2.5e+42
++ noib = 0.0
++ noic = 0.0
++ em = 41000000.0
++ ntnoi = 1.0
++ lintnoi = -1.0e-7
++ af = 1.0
++ kf = 0.0
++ tnoia = 15000000.0
++ tnoib = 9900000.0
++ rnoia = 0.94
++ rnoib = 0.26
+* Layout-Dependent Parasitics Model Parameters
++ xl = 0.0
++ xw = 0.0
++ dmcg = 0.0
++ dmdg = 0.0
++ dmcgt = 0.0
++ xgw = 0.0
++ xgl = 0.0
++ ngcon = 1.0
+* Asymmetric Source/Drain Junction Diode Model Parameters
++ jss = 0.00275
++ jsws = 6.0e-10
++ ijthsfwd = 0.1
++ ijthsrev = 0.1
++ bvs = 11.7
++ xjbvs = 1.0
++ pbs = 0.729
++ cjs = 0.00163782571
++ mjs = 0.44
++ pbsws = 0.2
++ cjsws = 4.49076474e-11
++ mjsws = 0.0009
++ pbswgs = 0.95578
++ cjswgs = 2.91230478e-10
++ mjswgs = 0.8
+* Temperature Dependence Parameters
++ tnom = 30.0
++ kt1 = -1.137700705e-01 lkt1 = -2.045047907e-08 wkt1 = -8.760734360e-16 pkt1 = 1.671425220e-22
++ kt2 = -0.028878939
++ at = -9.874845431e+03 lat = 1.022523909e-02 wat = -2.813644242e-10 pat = 5.368038546e-17
++ ute = -9.888383039e-01 lute = -5.536703130e-08 wute = -1.908327907e-07 pute = 3.640822481e-14
++ ua1 = -2.3847336e-11
++ ub1 = 7.0775317e-19
++ uc1 = 1.4718625e-10
++ kt1l = 0.0
++ prt = 0.0
++ tvoff = 0.0
++ njs = 1.2928
++ tpb = 0.0012287
++ tcj = 0.000792
++ tpbsw = 0.0
++ tcjsw = 1.0e-5
++ tpbswg = 0.0
++ tcjswg = 0.0
++ xtis = 2.0
++ tvfbsdoff = 0.0
+* DW AND DL Parameters
++ ll = 0.0
++ wl = 0.0
++ lln = 1.0
++ wln = 1.0
++ lw = 0.0
++ ww = 0.0
++ lwn = 1.0
++ wwn = 1.0
++ lwl = 0.0
++ wwl = 0.0
++ llc = 0.0
++ wlc = 0.0
++ lwc = 0.0
++ wwc = 0.0
++ lwlc = 0.0
++ wwlc = 0.0
+* Stress Parameters
++ saref = 1.04e-6
++ sbref = 1.04e-6
++ kvth0 = 9.8e-9
++ lkvth0 = 0.0
++ wkvth0 = 2.0e-7
++ pkvth0 = 0.0
++ llodvth = 0.0
++ wlodvth = 1.0
++ wlod = 0.0
++ stk2 = 0.0
++ lodk2 = 1.0
++ lodeta0 = 1.0
++ ku0 = -2.7e-8
++ lku0 = 0.0
++ wku0 = 0.0
++ pku0 = 0.0
++ tku0 = 0.0
++ llodku0 = 0.0
++ wlodku0 = 1.0
++ kvsat = 0.2
++ steta0 = 0.0
+* Well Proximity Effect Parameters
+.model sky130_fd_pr__special_nfet_01v8__model.1 nmos
+* Model Flag Parameters
++ lmin = 1.5e-07 lmax = 1.8e-07 wmin = 3.6e-07 wmax = 3.9e-7
++ level = 54.0
++ version = 4.5
++ binunit = 2.0
++ mobmod = 0.0
++ capmod = 2.0
++ igcmod = 0.0
++ igbmod = 0.0
++ geomod = 0.0
++ diomod = 1.0
++ rdsmod = 0.0
++ rbodymod = 1.0
++ rgatemod = 0.0
++ permod = 1.0
++ acnqsmod = 0.0
++ trnqsmod = 0.0
++ fnoimod = 1.0
++ tnoimod = 1.0
++ tempmod = 0.0
+* Process Parameters
+*(mismatch parameter sky130_fd_pr__special_nfet_01v8__toxe_slope_spectre)
++ toxe = {4.363696e-09+MC_MM_SWITCH*AGAUSS(0,1.0,1)*(4.148e-9*1.052*(sky130_fd_pr__special_nfet_01v8__toxe_slope/sqrt(l*w*mult)))}
++ toxm = 4.148e-9
++ dtox = 0.0
++ epsrox = 3.9
++ xj = 1.5e-7
++ ngate = 1.0e+23
++ ndep = 1.7e+17
++ nsd = 1.0e+20
++ rsh = 1.0
++ rshg = 0.1
+* Basic Model Parameters
++ wint = 5.4034e-8
++ lint = -5.393e-9
+*(mismatch parameter sky130_fd_pr__special_nfet_01v8__vth0_slope_spectre)
++ vth0 = {-5.540233200e-01+MC_MM_SWITCH*AGAUSS(0,1.0,1)*(sky130_fd_pr__special_nfet_01v8__vth0_slope/sqrt(l*w*mult))} lvth0 = 2.045062455e-07 wvth0 = 2.988973523e-07 pvth0 = -5.702543026e-14
++ k1 = 0.90707349
++ k2 = -2.325260563e-01 lk2 = 1.449116137e-08 wk2 = 2.601281122e-08 pk2 = -4.962880202e-15
++ k3 = 2.0
++ k3b = 0.54
++ w0 = 0.0
++ dvt0 = 0.0
++ dvt1 = 0.53
++ dvt2 = -0.032
++ dvt0w = -3.58
++ dvt1w = 1670600.0
++ dvt2w = 0.068
++ dsub = 3.308003241e+00 ldsub = -5.121217546e-07 wdsub = -8.409553457e-07 pdsub = 1.604425066e-13
++ minv = 0.0
++ voffl = 5.8197729e-9
++ lpe0 = 1.0325e-7
++ lpeb = -7.082e-8
++ vbm = -3.0
++ dvtp0 = 0.0
++ dvtp1 = 0.0
++ phin = 0.0
++ cdsc = 0.0
++ cdscb = 0.0
++ cdscd = 0.002052
++ cit = 0.0
+*(mismatch parameter sky130_fd_pr__special_nfet_01v8__voff_slope_spectre)
++ voff = {-0.20753+MC_MM_SWITCH*AGAUSS(0,1.0,1)*(sky130_fd_pr__special_nfet_01v8__voff_slope/sqrt(l*w*mult))}
++ nfactor = -1.343760560e+01 lnfactor = 2.647399117e-06 wnfactor = 1.621325926e-06 pnfactor = -3.093262881e-13
++ eta0 = 0.0
++ etab = -0.043998
++ u0 = -1.159522987e-02 lu0 = 6.218713526e-09 wu0 = -1.281479905e-08 pu0 = 2.444884252e-15
++ ua = -1.072897415e-09 lua = -5.273245830e-18 wua = 1.329016093e-16 pua = -2.535576643e-23
++ ub = -6.163134324e-18 lub = 1.399223441e-24 wub = 5.016781923e-25 pub = -9.571317560e-32
++ uc = -9.715009267e-11 luc = 3.598397435e-17 wuc = 9.805419118e-17 puc = -1.870736692e-23
++ ud = 0.0
++ up = 0.0
++ lp = 1.0
++ eu = 1.67
++ vtl = 0.0
++ xn = 3.0
++ vsat = 6.616972904e+05 lvsat = -7.806300910e-02 wvsat = -1.217336119e-01 pvsat = 2.322506889e-8
++ a0 = 1.5
++ ags = 1.25
++ a1 = 0.0
++ a2 = 0.42385546
++ b0 = 3.055925333e-06 lb0 = -5.964526183e-13 wb0 = -3.644712082e-13 pb0 = 6.953600393e-20
++ b1 = 2.309501807e-06 lb1 = -4.486595707e-13 wb1 = -1.372677015e-12 pb1 = 2.618875569e-19
++ keta = -1.131181040e+00 lketa = 2.027683223e-07 wketa = 3.716864668e-07 pketa = -7.091257426e-14
++ dwg = 0.0
++ dwb = 0.0
++ pclm = 2.438497216e-02 lpclm = 2.990857260e-08 wpclm = 1.113922828e-07 ppclm = -2.125208807e-14
++ pdiblc1 = 0.35697215
++ pdiblc2 = 0.0084061121
++ pdiblcb = -0.10329577
++ drout = 0.50332666
++ pscbe1 = 791419880.0
++ pscbe2 = 1.0e-12
++ pvag = 0.0
++ delta = 0.01
++ fprout = 0.0
++ pdits = 0.0
++ pditsl = 0.0
++ pditsd = 0.0
++ lambda = 0.0
++ lc = 5.0e-9
+* Parameters FOR Asymmetric AND Bias-Dependent RDS Model
++ rdsw = 65.968
++ rsw = 0.0
++ rdw = 0.0
++ rdswmin = 0.0
++ rdwmin = 0.0
++ rswmin = 0.0
++ prwb = 0.0
++ prwg = 0.021507
++ wr = 1.0
+* Impact Ionization Current Model Parameters
++ alpha0 = 1.673659202e-07 lalpha0 = -2.208651686e-14 walpha0 = 1.811849002e-22 palpha0 = -3.456754693e-29
++ alpha1 = 0.85
++ beta0 = 1.734774334e+01 lbeta0 = -5.623881607e-07 wbeta0 = 3.171862772e-17 pbeta0 = -6.053824109e-24
+* Gidl Induced Drain Leakage Model Parameters
++ agidl = 0.0
++ bgidl = 2300000000.0
++ cgidl = 0.5
++ egidl = 0.8
+* Gate Dielectric Tunneling Current Model Parameters
++ toxref = 4.148e-9
++ dlcig = 0.0
++ aigbacc = 1.0
++ bigbacc = 0.0
++ cigbacc = 0.0
++ nigbacc = 0.0
++ aigbinv = 0.35
++ bigbinv = 0.03
++ cigbinv = 0.006
++ eigbinv = 1.1
++ nigbinv = 0.0
++ aigc = 0.43
++ bigc = 0.054
++ cigc = 0.075
++ aigsd = 0.43
++ bigsd = 0.054
++ cigsd = 0.075
++ nigc = 0.0
++ poxedge = 1.0
++ pigcd = 1.0
++ ntox = 1.0
++ vfbsdoff = 0.0
+* Charge AND Capacitance Model Parameters
++ dlc = -6.928e-9
++ dwc = 3.2175e-8
++ xpart = 0.0
++ cgso = 2.4384e-10
++ cgdo = 2.4384e-10
++ cgbo = 1.0e-13
++ cgdl = 0.0
++ cgsl = 0.0
++ clc = 1.0e-7
++ cle = 0.6
++ cf = 1.4067e-12
++ ckappas = 0.6
++ vfbcv = -1.0
++ acde = 0.4
++ moin = 6.9
++ noff = 3.4037
++ voffcv = -0.17287
+* High-Speed/RF Model Parameters
++ xrcrg1 = 12.0
++ xrcrg2 = 1.0
++ rbpb = 50.0
++ rbpd = 50.0
++ rbps = 50.0
++ rbdb = 50.0
++ rbsb = 50.0
++ gbmin = 1.0e-12
+* Flicker AND Thermal Noise Model Parameters
++ ef = 0.84
++ noia = 2.5e+42
++ noib = 0.0
++ noic = 0.0
++ em = 41000000.0
++ ntnoi = 1.0
++ lintnoi = -1.0e-7
++ af = 1.0
++ kf = 0.0
++ tnoia = 15000000.0
++ tnoib = 9900000.0
++ rnoia = 0.94
++ rnoib = 0.26
+* Layout-Dependent Parasitics Model Parameters
++ xl = 0.0
++ xw = 0.0
++ dmcg = 0.0
++ dmdg = 0.0
++ dmcgt = 0.0
++ xgw = 0.0
++ xgl = 0.0
++ ngcon = 1.0
+* Asymmetric Source/Drain Junction Diode Model Parameters
++ jss = 0.00275
++ jsws = 6.0e-10
++ ijthsfwd = 0.1
++ ijthsrev = 0.1
++ bvs = 11.7
++ xjbvs = 1.0
++ pbs = 0.729
++ cjs = 0.00163782571
++ mjs = 0.44
++ pbsws = 0.2
++ cjsws = 4.49076474e-11
++ mjsws = 0.0009
++ pbswgs = 0.95578
++ cjswgs = 2.91230478e-10
++ mjswgs = 0.8
+* Temperature Dependence Parameters
++ tnom = 30.0
++ kt1 = -1.137700734e-01 lkt1 = -2.045047852e-08 wkt1 = -6.743006153e-17 pkt1 = 1.286470930e-23
++ kt2 = -0.028878939
++ at = -9.874846353e+03 lat = 1.022523927e-02 wat = -2.139387652e-11 pat = 4.081666702e-18
++ ute = -1.015327828e+00 lute = -5.031320101e-08 wute = -1.833645463e-07 pute = 3.498338833e-14
++ ua1 = -2.3847336e-11
++ ub1 = 7.0775317e-19
++ uc1 = 1.4718625e-10
++ kt1l = 0.0
++ prt = 0.0
++ tvoff = 0.0
++ njs = 1.2928
++ tpb = 0.0012287
++ tcj = 0.000792
++ tpbsw = 0.0
++ tcjsw = 1.0e-5
++ tpbswg = 0.0
++ tcjswg = 0.0
++ xtis = 2.0
++ tvfbsdoff = 0.0
+* DW AND DL Parameters
++ ll = 0.0
++ wl = 0.0
++ lln = 1.0
++ wln = 1.0
++ lw = 0.0
++ ww = 0.0
++ lwn = 1.0
++ wwn = 1.0
++ lwl = 0.0
++ wwl = 0.0
++ llc = 0.0
++ wlc = 0.0
++ lwc = 0.0
++ wwc = 0.0
++ lwlc = 0.0
++ wwlc = 0.0
+* Stress Parameters
++ saref = 1.04e-6
++ sbref = 1.04e-6
++ kvth0 = 9.8e-9
++ lkvth0 = 0.0
++ wkvth0 = 2.0e-7
++ pkvth0 = 0.0
++ llodvth = 0.0
++ wlodvth = 1.0
++ wlod = 0.0
++ stk2 = 0.0
++ lodk2 = 1.0
++ lodeta0 = 1.0
++ ku0 = -2.7e-8
++ lku0 = 0.0
++ wku0 = 0.0
++ pku0 = 0.0
++ tku0 = 0.0
++ llodku0 = 0.0
++ wlodku0 = 1.0
++ kvsat = 0.2
++ steta0 = 0.0
+.ends sky130_fd_pr__special_nfet_01v8
+* Well Proximity Effect Parameters

--- a/cells/special_nfet_01v8/sky130_fd_pr__special_nfet_01v8__leak.corner.spice
+++ b/cells/special_nfet_01v8/sky130_fd_pr__special_nfet_01v8__leak.corner.spice
@@ -1,0 +1,72 @@
+* Copyright 2020 The SkyWater PDK Authors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+
+* SKY130 Spice File.
+* Number of bins: 2
+.param
++ sky130_fd_pr__special_nfet_01v8__toxe_mult = 0.948
++ sky130_fd_pr__special_nfet_01v8__rshn_mult = 1.0
++ sky130_fd_pr__special_nfet_01v8__overlap_mult = 0.94816
++ sky130_fd_pr__special_nfet_01v8__lint_diff = 1.7325e-8
++ sky130_fd_pr__special_nfet_01v8__wint_diff = -3.2175e-8
++ sky130_fd_pr__special_nfet_01v8__dlc_diff = 12.773e-9
++ sky130_fd_pr__special_nfet_01v8__dwc_diff = -3.2175e-8
+*
+* sky130_fd_pr__special_nfet_01v8, Bin 000, W = 0.36, L = 0.15
+* -----------------------------------
++ sky130_fd_pr__special_nfet_01v8__ub_diff_0 = 4.16095e-19
++ sky130_fd_pr__special_nfet_01v8__eta0_diff_0 = 3.2537e-5
++ sky130_fd_pr__special_nfet_01v8__tvoff_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__rdsw_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__a0_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__vsat_diff_0 = -65067.0
++ sky130_fd_pr__special_nfet_01v8__kt1_diff_0 = -0.045241
++ sky130_fd_pr__special_nfet_01v8__vth0_diff_0 = -0.19181
++ sky130_fd_pr__special_nfet_01v8__pdits_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__b0_diff_0 = -7.39989e-7
++ sky130_fd_pr__special_nfet_01v8__b1_diff_0 = 2.7011e-8
++ sky130_fd_pr__special_nfet_01v8__voff_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__pditsd_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__pclm_diff_0 = 0.00091873
++ sky130_fd_pr__special_nfet_01v8__u0_diff_0 = -0.0083504
++ sky130_fd_pr__special_nfet_01v8__nfactor_diff_0 = 0.27572
++ sky130_fd_pr__special_nfet_01v8__keta_diff_0 = 0.00306555
++ sky130_fd_pr__special_nfet_01v8__ags_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__k2_diff_0 = 0.020341
++ sky130_fd_pr__special_nfet_01v8__ua_diff_0 = -4.02468e-11
+*
+* sky130_fd_pr__special_nfet_01v8, Bin 001, W = 0.39, L = 0.15
+* -----------------------------------
++ sky130_fd_pr__special_nfet_01v8__ua_diff_1 = -4.99625e-12
++ sky130_fd_pr__special_nfet_01v8__ub_diff_1 = 3.05799e-19
++ sky130_fd_pr__special_nfet_01v8__eta0_diff_1 = 1.15988e-5
++ sky130_fd_pr__special_nfet_01v8__tvoff_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__a0_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__rdsw_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__vsat_diff_1 = -59191.0
++ sky130_fd_pr__special_nfet_01v8__kt1_diff_1 = -0.053893
++ sky130_fd_pr__special_nfet_01v8__vth0_diff_1 = -0.19305
++ sky130_fd_pr__special_nfet_01v8__pdits_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__b0_diff_1 = -4.77112e-7
++ sky130_fd_pr__special_nfet_01v8__b1_diff_1 = 2.47721e-8
++ sky130_fd_pr__special_nfet_01v8__voff_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__pditsd_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__pclm_diff_1 = 0.00032751
++ sky130_fd_pr__special_nfet_01v8__u0_diff_1 = -0.0072906
++ sky130_fd_pr__special_nfet_01v8__nfactor_diff_1 = 0.36174
++ sky130_fd_pr__special_nfet_01v8__keta_diff_1 = 0.0010928
++ sky130_fd_pr__special_nfet_01v8__ags_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__k2_diff_1 = 0.022274
+*
+.include "sky130_fd_pr__special_nfet_01v8.pm3.spice"

--- a/cells/special_nfet_01v8/sky130_fd_pr__special_nfet_01v8__leak.pm3.spice
+++ b/cells/special_nfet_01v8/sky130_fd_pr__special_nfet_01v8__leak.pm3.spice
@@ -1,0 +1,574 @@
+* Copyright 2020 The SkyWater PDK Authors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+
+* SKY130 Spice File.
+.param sky130_fd_pr__nfet_01v8__toxe_slope_spectre = 0.0
+.param sky130_fd_pr__nfet_01v8__vth0_slope_spectre = 0.0
+.param sky130_fd_pr__nfet_01v8__voff_slope_spectre = 0.0
+* statistics {
+*   process {
+*   }
+*   mismatch {
+*     vary sky130_fd_pr__nfet_01v8__toxe_slope_spectre dist=gauss std = 1.0
+*     vary sky130_fd_pr__nfet_01v8__vth0_slope_spectre dist=gauss std = 1.0
+*     vary sky130_fd_pr__nfet_01v8__voff_slope_spectre dist=gauss std = 1.0
+*   }
+* }
+.subckt  sky130_fd_pr__nfet_01v8 d g s b
++ 
+.param  l = 1 w = 1 nf = 1.0 ad = 0 as = 0 pd = 0 ps = 0 nrd = 0 nrs = 0 sa = 0 sb = 0 sd = 0 mult = 1
+msky130_fd_pr__nfet_01v8 d g s b sky130_fd_pr__nfet_01v8__model l = {l} w = {w} nf = {nf} ad = {ad} as = {as} pd = {pd} ps = {ps} nrd = {nrd} nrs = {nrs} sa = {sa} sb = {sb} sd = {sd}
+.model sky130_fd_pr__nfet_01v8__model.0 nmos
+* Model Flag Parameters
++ lmin = 1.5e-07 lmax = 1.8e-07 wmin = 3.9e-07 wmax = 4.2e-7
++ level = 54.0
++ version = 4.5
++ binunit = 2.0
++ mobmod = 0.0
++ capmod = 2.0
++ igcmod = 0.0
++ igbmod = 0.0
++ geomod = 0.0
++ diomod = 1.0
++ rdsmod = 0.0
++ rbodymod = 1.0
++ rgatemod = 0.0
++ permod = 1.0
++ acnqsmod = 0.0
++ trnqsmod = 0.0
++ fnoimod = 1.0
++ tnoimod = 1.0
++ tempmod = 0.0
+* Process Parameters
+*(mismatch parameter sky130_fd_pr__nfet_01v8__toxe_slope_spectre)
++ toxe = {3.932304e-09+MC_MM_SWITCH*AGAUSS(0,1.0,1)*(4.148e-9*0.948*(sky130_fd_pr__nfet_01v8__toxe_slope/sqrt(l*w*mult)))}
++ toxm = 4.148e-9
++ dtox = 0.0
++ epsrox = 3.9
++ xj = 1.5e-7
++ ngate = 1.0e+23
++ ndep = 1.7e+17
++ nsd = 1.0e+20
++ rsh = 1.0
++ rshg = 0.1
+* Basic Model Parameters
++ wint = -1.0316e-8
++ lint = 2.9257e-8
+*(mismatch parameter sky130_fd_pr__nfet_01v8__vth0_slope_spectre)
++ vth0 = {-3.435598678e+00+MC_MM_SWITCH*AGAUSS(0,1.0,1)*(sky130_fd_pr__nfet_01v8__vth0_slope/sqrt(l*w*mult))} lvth0 = 4.579583245e-07 wvth0 = 1.796188423e-06 pvth0 = -2.182117468e-13
++ k1 = 0.90707349
++ k2 = -2.107921637e+00 lk2 = 2.418914594e-07 wk2 = 8.411261769e-07 pk2 = -1.021850547e-13
++ k3 = 2.0
++ k3b = 0.54
++ w0 = 0.0
++ dvt0 = 0.0
++ dvt1 = 0.53
++ dvt2 = -0.032
++ dvt0w = -3.58
++ dvt1w = 1670600.0
++ dvt2w = 0.068
++ dsub = 2.948957557e+00 ldsub = -2.824825950e-07 wdsub = -1.024569669e-06 pdsub = 1.244708708e-13
++ minv = 0.0
++ voffl = 5.8197729e-9
++ lpe0 = 1.0325e-7
++ lpeb = -7.082e-8
++ vbm = -3.0
++ dvtp0 = 0.0
++ dvtp1 = 0.0
++ phin = 0.0
++ cdsc = 0.0
++ cdscb = 0.0
++ cdscd = 0.002052
++ cit = 0.0
+*(mismatch parameter sky130_fd_pr__nfet_01v8__voff_slope_spectre)
++ voff = {2.710812388e+00+MC_MM_SWITCH*AGAUSS(0,1.0,1)*(sky130_fd_pr__nfet_01v8__voff_slope/sqrt(l*w*mult))} lvoff = -3.616983712e-07 wvoff = -1.296377536e-06 pvoff = 1.574917213e-13
++ nfactor = -9.718055751e+00 lnfactor = 1.573138706e-06 wnfactor = 6.109565162e-06 pnfactor = -7.422266333e-13
++ eta0 = 4.841478680e-04 leta0 = -5.881718202e-11 weta0 = -2.133310221e-10 peta0 = 2.591673255e-17
++ etab = -0.043998
++ u0 = 2.649207452e-01 lu0 = -2.936665834e-08 wu0 = -1.102281398e-07 pu0 = 1.339117580e-14
++ ua = -3.027207701e-09 lua = 2.268890396e-16 wua = 8.320734854e-16 pua = -1.010852794e-22
++ ub = 1.372746819e-17 lub = -1.369895353e-24 wub = -5.574265064e-24 pub = 6.771951656e-31
++ uc = -1.088917355e-10 luc = 2.433980945e-17 wuc = 1.194633573e-16 puc = -1.451312543e-23
++ ud = 0.0
++ up = 0.0
++ lp = 1.0
++ eu = 1.67
++ vtl = 0.0
++ xn = 3.0
++ vsat = 8.613456549e+05 lvsat = -8.297683985e-02 wvsat = -2.337724555e-01 pvsat = 2.840008053e-8
++ a0 = 1.5
++ ags = 1.25
++ a1 = 0.0
++ a2 = 0.42385546
++ b0 = -4.381579665e-06 lb0 = 6.623392016e-13 wb0 = 4.176607507e-12 pb0 = -5.073993396e-19
++ b1 = 7.740561823e-08 lb1 = -7.414122714e-15 wb1 = -3.557294977e-14 pb1 = 4.321615375e-21
++ keta = -8.705490917e-01 lketa = 9.745280022e-08 wketa = 3.857447104e-07 pketa = -4.686258189e-14
++ dwg = 0.0
++ dwb = 0.0
++ pclm = 3.277891720e-02 lpclm = 1.802500936e-08 wpclm = 1.156053743e-07 ppclm = -1.404443450e-14
++ pdiblc1 = 0.35697215
++ pdiblc2 = 0.0084061121
++ pdiblcb = -0.10329577
++ drout = 0.50332666
++ pscbe1 = 791419880.0
++ pscbe2 = 1.0e-12
++ pvag = 0.0
++ delta = 0.01
++ fprout = 0.0
++ pdits = 0.0
++ pditsl = 0.0
++ pditsd = 0.0
++ lambda = 0.0
++ lc = 5.0e-9
+* Parameters FOR Asymmetric AND Bias-Dependent RDS Model
++ rdsw = 65.968
++ rsw = 0.0
++ rdw = 0.0
++ rdswmin = 0.0
++ rdwmin = 0.0
++ rswmin = 0.0
++ prwb = 0.0
++ prwg = 0.021507
++ wr = 1.0
+* Impact Ionization Current Model Parameters
++ alpha0 = 1.174699132e-07 lalpha0 = -8.002272280e-15 walpha0 = 2.976834824e-21 palpha0 = -3.616437609e-28
++ alpha1 = 0.85
++ beta0 = 1.607724329e+01 lbeta0 = -2.037615779e-07 wbeta0 = 2.059408644e-14 pbeta0 = -2.501892027e-21
+* Gidl Induced Drain Leakage Model Parameters
++ agidl = 0.0
++ bgidl = 2300000000.0
++ cgidl = 0.5
++ egidl = 0.8
+* Gate Dielectric Tunneling Current Model Parameters
++ toxref = 4.148e-9
++ dlcig = 0.0
++ aigbacc = 1.0
++ bigbacc = 0.0
++ cigbacc = 0.0
++ nigbacc = 0.0
++ aigbinv = 0.35
++ bigbinv = 0.03
++ cigbinv = 0.006
++ eigbinv = 1.1
++ nigbinv = 0.0
++ aigc = 0.43
++ bigc = 0.054
++ cigc = 0.075
++ aigsd = 0.43
++ bigsd = 0.054
++ cigsd = 0.075
++ nigc = 0.0
++ poxedge = 1.0
++ pigcd = 1.0
++ ntox = 1.0
++ vfbsdoff = 0.0
+* Charge AND Capacitance Model Parameters
++ dlc = 2.3267e-8
++ dwc = -3.2175e-8
++ xpart = 0.0
++ cgso = 2.4083264e-10
++ cgdo = 2.4083264e-10
++ cgbo = 1.0e-13
++ cgdl = 0.0
++ cgsl = 0.0
++ clc = 1.0e-7
++ cle = 0.6
++ cf = 1.4067e-12
++ ckappas = 0.6
++ vfbcv = -1.0
++ acde = 0.4
++ moin = 6.9
++ noff = 3.4037
++ voffcv = -0.17287
+* High-Speed/RF Model Parameters
++ xrcrg1 = 12.0
++ xrcrg2 = 1.0
++ rbpb = 50.0
++ rbpd = 50.0
++ rbps = 50.0
++ rbdb = 50.0
++ rbsb = 50.0
++ gbmin = 1.0e-12
+* Flicker AND Thermal Noise Model Parameters
++ ef = 0.84
++ noia = 2.5e+42
++ noib = 0.0
++ noic = 0.0
++ em = 41000000.0
++ ntnoi = 1.0
++ lintnoi = -1.0e-7
++ af = 1.0
++ kf = 0.0
++ tnoia = 15000000.0
++ tnoib = 9900000.0
++ rnoia = 0.94
++ rnoib = 0.26
+* Layout-Dependent Parasitics Model Parameters
++ xl = 0.0
++ xw = 0.0
++ dmcg = 0.0
++ dmdg = 0.0
++ dmcgt = 0.0
++ xgw = 0.0
++ xgl = 0.0
++ ngcon = 1.0
+* Asymmetric Source/Drain Junction Diode Model Parameters
++ jss = 0.00275
++ jsws = 6.0e-10
++ ijthsfwd = 0.1
++ ijthsrev = 0.1
++ bvs = 11.7
++ xjbvs = 1.0
++ pbs = 0.729
++ cjs = 0.001041645846
++ mjs = 0.44
++ pbsws = 0.2
++ cjsws = 2.856175336e-11
++ mjsws = 0.0009
++ pbswgs = 0.95578
++ cjswgs = 1.852257592e-10
++ mjswgs = 0.8
+* Temperature Dependence Parameters
++ tnom = 30.0
++ kt1 = -2.409528512e+00 lkt1 = 2.658803443e-07 wkt1 = 9.912274339e-07 pkt1 = -1.204202560e-13
++ kt2 = -0.028878939
++ at = 1.322515441e+04 lat = 3.704755975e-03 wat = -3.293820191e-10 pat = 4.001532216e-17
++ ute = -9.550152712e-01 lute = -3.936485696e-08 wute = -2.234003926e-07 pute = 2.714002010e-14
++ ua1 = -2.3847336e-11
++ ub1 = 7.0775317e-19
++ uc1 = 1.4718625e-10
++ kt1l = 0.0
++ prt = 0.0
++ tvoff = -3.511084150e-02 ltvoff = 4.452916439e-09 wtvoff = 1.698327406e-08 ptvoff = -2.063230032e-15
++ njs = 1.2928
++ tpb = 0.0012287
++ tcj = 0.000792
++ tpbsw = 0.0
++ tcjsw = 1.0e-5
++ tpbswg = 0.0
++ tcjswg = 0.0
++ xtis = 2.0
++ tvfbsdoff = 0.0
+* DW AND DL Parameters
++ ll = 0.0
++ wl = 0.0
++ lln = 1.0
++ wln = 1.0
++ lw = 0.0
++ ww = 0.0
++ lwn = 1.0
++ wwn = 1.0
++ lwl = 0.0
++ wwl = 0.0
++ llc = 0.0
++ wlc = 0.0
++ lwc = 0.0
++ wwc = 0.0
++ lwlc = 0.0
++ wwlc = 0.0
+* Stress Parameters
++ saref = 1.04e-6
++ sbref = 1.04e-6
++ kvth0 = 9.8e-9
++ lkvth0 = 0.0
++ wkvth0 = 2.0e-7
++ pkvth0 = 0.0
++ llodvth = 0.0
++ wlodvth = 1.0
++ wlod = 0.0
++ stk2 = 0.0
++ lodk2 = 1.0
++ lodeta0 = 1.0
++ ku0 = -2.7e-8
++ lku0 = 0.0
++ wku0 = 0.0
++ pku0 = 0.0
++ tku0 = 0.0
++ llodku0 = 0.0
++ wlodku0 = 1.0
++ kvsat = 0.2
++ steta0 = 0.0
+* Well Proximity Effect Parameters
+.model sky130_fd_pr__nfet_01v8__model.1 nmos
+* Model Flag Parameters
++ lmin = 1.5e-07 lmax = 1.8e-07 wmin = 3.6e-07 wmax = 3.9e-7
++ level = 54.0
++ version = 4.5
++ binunit = 2.0
++ mobmod = 0.0
++ capmod = 2.0
++ igcmod = 0.0
++ igbmod = 0.0
++ geomod = 0.0
++ diomod = 1.0
++ rdsmod = 0.0
++ rbodymod = 1.0
++ rgatemod = 0.0
++ permod = 1.0
++ acnqsmod = 0.0
++ trnqsmod = 0.0
++ fnoimod = 1.0
++ tnoimod = 1.0
++ tempmod = 0.0
+* Process Parameters
+*(mismatch parameter sky130_fd_pr__nfet_01v8__toxe_slope_spectre)
++ toxe = {3.932304e-09+MC_MM_SWITCH*AGAUSS(0,1.0,1)*(4.148e-9*0.948*(sky130_fd_pr__nfet_01v8__toxe_slope/sqrt(l*w*mult)))}
++ toxm = 4.148e-9
++ dtox = 0.0
++ epsrox = 3.9
++ xj = 1.5e-7
++ ngate = 1.0e+23
++ ndep = 1.7e+17
++ nsd = 1.0e+20
++ rsh = 1.0
++ rshg = 0.1
+* Basic Model Parameters
++ wint = -1.0316e-8
++ lint = 2.9257e-8
+*(mismatch parameter sky130_fd_pr__nfet_01v8__vth0_slope_spectre)
++ vth0 = {-3.531268488e-01+MC_MM_SWITCH*AGAUSS(0,1.0,1)*(sky130_fd_pr__nfet_01v8__vth0_slope/sqrt(l*w*mult))} lvth0 = 8.348115179e-08 wvth0 = 5.304268509e-07 pvth0 = -6.443943641e-14
++ k1 = 0.90707349
++ k2 = -4.094792879e-01 lk2 = 3.555449219e-08 wk2 = 1.436913983e-07 pk2 = -1.745649321e-14
++ k3 = 2.0
++ k3b = 0.54
++ w0 = 0.0
++ dvt0 = 0.0
++ dvt1 = 0.53
++ dvt2 = -0.032
++ dvt0w = -3.58
++ dvt1w = 1670600.0
++ dvt2w = 0.068
++ dsub = 3.018083006e+00 ldsub = -2.908803693e-07 wdsub = -1.052954790e-06 pdsub = 1.279192657e-13
++ minv = 0.0
++ voffl = 5.8197729e-9
++ lpe0 = 1.0325e-7
++ lpeb = -7.082e-8
++ vbm = -3.0
++ dvtp0 = 0.0
++ dvtp1 = 0.0
++ phin = 0.0
++ cdsc = 0.0
++ cdscb = 0.0
++ cdscd = 0.002052
++ cit = 0.0
+*(mismatch parameter sky130_fd_pr__nfet_01v8__voff_slope_spectre)
++ voff = {-4.462175937e-01+MC_MM_SWITCH*AGAUSS(0,1.0,1)*(sky130_fd_pr__nfet_01v8__voff_slope/sqrt(l*w*mult))} lvoff = 2.183657320e-8
++ nfactor = -2.972044984e+00 lnfactor = 7.535928418e-07 wnfactor = 3.339437269e-06 pnfactor = -4.056948761e-13
++ eta0 = 7.747629855e-04 leta0 = -9.412284665e-11 weta0 = -3.326668770e-10 peta0 = 4.041436822e-17
++ etab = -0.043998
++ u0 = 6.530240354e-02 lu0 = -5.115824484e-09 wu0 = -2.825846097e-08 pu0 = 3.433007390e-15
++ ua = -2.717298978e-09 lua = 1.892394685e-16 wua = 7.048150466e-16 pua = -8.562516075e-23
++ ub = 1.193222840e-17 lub = -1.151798852e-24 wub = -4.837082158e-24 pub = 5.876377631e-31
++ uc = -1.169516676e-10 luc = 2.531897836e-17 wuc = 1.227730234e-16 puc = -1.491520352e-23
++ ud = 0.0
++ up = 0.0
++ lp = 1.0
++ eu = 1.67
++ vtl = 0.0
++ xn = 3.0
++ vsat = 2.513622016e+05 lvsat = -8.872390042e-03 wvsat = 1.670626994e-02 pvsat = -2.029577910e-9
++ a0 = 1.5
++ ags = 1.25
++ a1 = 0.0
++ a2 = 0.42385546
++ b0 = -4.381559583e-06 lb0 = 6.623367619e-13 wb0 = 4.176599261e-12 pb0 = -5.073983378e-19
++ b1 = 7.740263310e-08 lb1 = -7.413760063e-15 wb1 = -3.557172398e-14 pb1 = 4.321466459e-21
++ keta = -8.705488195e-01 lketa = 9.745276715e-08 wketa = 3.857445986e-07 pketa = -4.686256831e-14
++ dwg = 0.0
++ dwb = 0.0
++ pclm = 3.277875141e-02 lpclm = 1.802502951e-08 wpclm = 1.156054423e-07 ppclm = -1.404444277e-14
++ pdiblc1 = 0.35697215
++ pdiblc2 = 0.0084061121
++ pdiblcb = -0.10329577
++ drout = 0.50332666
++ pscbe1 = 791419880.0
++ pscbe2 = 1.0e-12
++ pvag = 0.0
++ delta = 0.01
++ fprout = 0.0
++ pdits = 0.0
++ pditsl = 0.0
++ pditsd = 0.0
++ lambda = 0.0
++ lc = 5.0e-9
+* Parameters FOR Asymmetric AND Bias-Dependent RDS Model
++ rdsw = 65.968
++ rsw = 0.0
++ rdw = 0.0
++ rdswmin = 0.0
++ rdwmin = 0.0
++ rswmin = 0.0
++ prwb = 0.0
++ prwg = 0.021507
++ wr = 1.0
+* Impact Ionization Current Model Parameters
++ alpha0 = 1.174699199e-07 lalpha0 = -8.002273094e-15 walpha0 = 2.268604107e-22 palpha0 = -2.756037423e-29
++ alpha1 = 0.85
++ beta0 = 1.607724334e+01 lbeta0 = -2.037615840e-07 wbeta0 = 3.967670636e-17 pbeta0 = -4.824585176e-24
+* Gidl Induced Drain Leakage Model Parameters
++ agidl = 0.0
++ bgidl = 2300000000.0
++ cgidl = 0.5
++ egidl = 0.8
+* Gate Dielectric Tunneling Current Model Parameters
++ toxref = 4.148e-9
++ dlcig = 0.0
++ aigbacc = 1.0
++ bigbacc = 0.0
++ cigbacc = 0.0
++ nigbacc = 0.0
++ aigbinv = 0.35
++ bigbinv = 0.03
++ cigbinv = 0.006
++ eigbinv = 1.1
++ nigbinv = 0.0
++ aigc = 0.43
++ bigc = 0.054
++ cigc = 0.075
++ aigsd = 0.43
++ bigsd = 0.054
++ cigsd = 0.075
++ nigc = 0.0
++ poxedge = 1.0
++ pigcd = 1.0
++ ntox = 1.0
++ vfbsdoff = 0.0
+* Charge AND Capacitance Model Parameters
++ dlc = 2.3267e-8
++ dwc = -3.2175e-8
++ xpart = 0.0
++ cgso = 2.4083264e-10
++ cgdo = 2.4083264e-10
++ cgbo = 1.0e-13
++ cgdl = 0.0
++ cgsl = 0.0
++ clc = 1.0e-7
++ cle = 0.6
++ cf = 1.4067e-12
++ ckappas = 0.6
++ vfbcv = -1.0
++ acde = 0.4
++ moin = 6.9
++ noff = 3.4037
++ voffcv = -0.17287
+* High-Speed/RF Model Parameters
++ xrcrg1 = 12.0
++ xrcrg2 = 1.0
++ rbpb = 50.0
++ rbpd = 50.0
++ rbps = 50.0
++ rbdb = 50.0
++ rbsb = 50.0
++ gbmin = 1.0e-12
+* Flicker AND Thermal Noise Model Parameters
++ ef = 0.84
++ noia = 2.5e+42
++ noib = 0.0
++ noic = 0.0
++ em = 41000000.0
++ ntnoi = 1.0
++ lintnoi = -1.0e-7
++ af = 1.0
++ kf = 0.0
++ tnoia = 15000000.0
++ tnoib = 9900000.0
++ rnoia = 0.94
++ rnoib = 0.26
+* Layout-Dependent Parasitics Model Parameters
++ xl = 0.0
++ xw = 0.0
++ dmcg = 0.0
++ dmdg = 0.0
++ dmcgt = 0.0
++ xgw = 0.0
++ xgl = 0.0
++ ngcon = 1.0
+* Asymmetric Source/Drain Junction Diode Model Parameters
++ jss = 0.00275
++ jsws = 6.0e-10
++ ijthsfwd = 0.1
++ ijthsrev = 0.1
++ bvs = 11.7
++ xjbvs = 1.0
++ pbs = 0.729
++ cjs = 0.001041645846
++ mjs = 0.44
++ pbsws = 0.2
++ cjsws = 2.856175336e-11
++ mjsws = 0.0009
++ pbswgs = 0.95578
++ cjswgs = 1.852257592e-10
++ mjswgs = 0.8
+* Temperature Dependence Parameters
++ tnom = 30.0
++ kt1 = 3.391387185e-01 lkt1 = -6.804424281e-08 wkt1 = -1.374632882e-07 pkt1 = 1.669986504e-14
++ kt2 = -0.028878939
++ at = 1.322515368e+04 lat = 3.704756064e-03 wat = -2.678728197e-11 pat = 3.254273906e-18
++ ute = -9.399429465e-01 lute = -4.119593340e-08 wute = -2.295895715e-07 pute = 2.789191868e-14
++ ua1 = -2.3847336e-11
++ ub1 = 7.0775317e-19
++ uc1 = 1.4718625e-10
++ kt1l = 0.0
++ prt = 0.0
++ tvoff = 6.248024980e-03 ltvoff = -5.716068133e-10
++ njs = 1.2928
++ tpb = 0.0012287
++ tcj = 0.000792
++ tpbsw = 0.0
++ tcjsw = 1.0e-5
++ tpbswg = 0.0
++ tcjswg = 0.0
++ xtis = 2.0
++ tvfbsdoff = 0.0
+* DW AND DL Parameters
++ ll = 0.0
++ wl = 0.0
++ lln = 1.0
++ wln = 1.0
++ lw = 0.0
++ ww = 0.0
++ lwn = 1.0
++ wwn = 1.0
++ lwl = 0.0
++ wwl = 0.0
++ llc = 0.0
++ wlc = 0.0
++ lwc = 0.0
++ wwc = 0.0
++ lwlc = 0.0
++ wwlc = 0.0
+* Stress Parameters
++ saref = 1.04e-6
++ sbref = 1.04e-6
++ kvth0 = 9.8e-9
++ lkvth0 = 0.0
++ wkvth0 = 2.0e-7
++ pkvth0 = 0.0
++ llodvth = 0.0
++ wlodvth = 1.0
++ wlod = 0.0
++ stk2 = 0.0
++ lodk2 = 1.0
++ lodeta0 = 1.0
++ ku0 = -2.7e-8
++ lku0 = 0.0
++ wku0 = 0.0
++ pku0 = 0.0
++ tku0 = 0.0
++ llodku0 = 0.0
++ wlodku0 = 1.0
++ kvsat = 0.2
++ steta0 = 0.0
+.ends sky130_fd_pr__nfet_01v8
+* Well Proximity Effect Parameters

--- a/cells/special_nfet_01v8/sky130_fd_pr__special_nfet_01v8__mismatch.corner.spice
+++ b/cells/special_nfet_01v8/sky130_fd_pr__special_nfet_01v8__mismatch.corner.spice
@@ -1,0 +1,22 @@
+* Copyright 2020 The SkyWater PDK Authors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+
+* SKY130 Spice File.
+.param sky130_fd_pr__special_nfet_01v8__toxe_slope=3.443e-03
+.param sky130_fd_pr__special_nfet_01v8__lint_slope=0.0
+.param sky130_fd_pr__special_nfet_01v8__nfactor_slope=0.0
+.param sky130_fd_pr__special_nfet_01v8__voff_slope=0.007
+.param sky130_fd_pr__special_nfet_01v8__vth0_slope=3.356e-03
+.param sky130_fd_pr__special_nfet_01v8__vth0_slope1=7.356e-03
+.param sky130_fd_pr__special_nfet_01v8__wint_slope=0

--- a/cells/special_nfet_01v8/sky130_fd_pr__special_nfet_01v8__sf.corner.spice
+++ b/cells/special_nfet_01v8/sky130_fd_pr__special_nfet_01v8__sf.corner.spice
@@ -1,0 +1,72 @@
+* Copyright 2020 The SkyWater PDK Authors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+
+* SKY130 Spice File.
+* Number of bins: 2
+.param
++ sky130_fd_pr__special_nfet_01v8__toxe_mult = 0.948
++ sky130_fd_pr__special_nfet_01v8__rshn_mult = 1.0
++ sky130_fd_pr__special_nfet_01v8__overlap_mult = 0.94816
++ sky130_fd_pr__special_nfet_01v8__lint_diff = 1.21275e-8
++ sky130_fd_pr__special_nfet_01v8__wint_diff = -3.2175e-8
++ sky130_fd_pr__special_nfet_01v8__dlc_diff = 12.773e-9
++ sky130_fd_pr__special_nfet_01v8__dwc_diff = -3.2175e-8
+*
+* sky130_fd_pr__special_nfet_01v8, Bin 000, W = 0.36, L = 0.15
+* -----------------------------------
++ sky130_fd_pr__special_nfet_01v8__ub_diff_0 = 4.16095e-19
++ sky130_fd_pr__special_nfet_01v8__eta0_diff_0 = 3.2537e-5
++ sky130_fd_pr__special_nfet_01v8__tvoff_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__rdsw_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__a0_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__vsat_diff_0 = -65067.0
++ sky130_fd_pr__special_nfet_01v8__kt1_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__vth0_diff_0 = -0.12224
++ sky130_fd_pr__special_nfet_01v8__pdits_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__b0_diff_0 = -7.39989e-7
++ sky130_fd_pr__special_nfet_01v8__b1_diff_0 = 2.7011e-8
++ sky130_fd_pr__special_nfet_01v8__voff_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__pditsd_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__pclm_diff_0 = 0.00091873
++ sky130_fd_pr__special_nfet_01v8__u0_diff_0 = -0.0083504
++ sky130_fd_pr__special_nfet_01v8__nfactor_diff_0 = 0.5935569
++ sky130_fd_pr__special_nfet_01v8__keta_diff_0 = 0.00306555
++ sky130_fd_pr__special_nfet_01v8__ags_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__k2_diff_0 = 0.020341
++ sky130_fd_pr__special_nfet_01v8__ua_diff_0 = -4.02468e-11
+*
+* sky130_fd_pr__special_nfet_01v8, Bin 001, W = 0.39, L = 0.15
+* -----------------------------------
++ sky130_fd_pr__special_nfet_01v8__ua_diff_1 = -4.99625e-12
++ sky130_fd_pr__special_nfet_01v8__ub_diff_1 = 3.05799e-19
++ sky130_fd_pr__special_nfet_01v8__eta0_diff_1 = 1.15988e-5
++ sky130_fd_pr__special_nfet_01v8__tvoff_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__a0_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__rdsw_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__vsat_diff_1 = -59191.0
++ sky130_fd_pr__special_nfet_01v8__kt1_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__vth0_diff_1 = -0.12953
++ sky130_fd_pr__special_nfet_01v8__pdits_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__b0_diff_1 = -4.77112e-7
++ sky130_fd_pr__special_nfet_01v8__b1_diff_1 = 2.47721e-8
++ sky130_fd_pr__special_nfet_01v8__voff_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__pditsd_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__pclm_diff_1 = 0.00032751
++ sky130_fd_pr__special_nfet_01v8__u0_diff_1 = -0.0072906
++ sky130_fd_pr__special_nfet_01v8__nfactor_diff_1 = 0.56383409
++ sky130_fd_pr__special_nfet_01v8__keta_diff_1 = 0.0010928
++ sky130_fd_pr__special_nfet_01v8__ags_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__k2_diff_1 = 0.022274
+*
+.include "sky130_fd_pr__special_nfet_01v8__sf.pm3.spice"

--- a/cells/special_nfet_01v8/sky130_fd_pr__special_nfet_01v8__sf.pm3.spice
+++ b/cells/special_nfet_01v8/sky130_fd_pr__special_nfet_01v8__sf.pm3.spice
@@ -1,0 +1,574 @@
+* Copyright 2020 The SkyWater PDK Authors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+
+* SKY130 Spice File.
+.param sky130_fd_pr__special_nfet_01v8__toxe_slope_spectre = 0.0
+.param sky130_fd_pr__special_nfet_01v8__vth0_slope_spectre = 0.0
+.param sky130_fd_pr__special_nfet_01v8__voff_slope_spectre = 0.0
+* statistics {
+*   process {
+*   }
+*   mismatch {
+*     vary sky130_fd_pr__special_nfet_01v8__toxe_slope_spectre dist=gauss std = 1.0
+*     vary sky130_fd_pr__special_nfet_01v8__vth0_slope_spectre dist=gauss std = 1.0
+*     vary sky130_fd_pr__special_nfet_01v8__voff_slope_spectre dist=gauss std = 1.0
+*   }
+* }
+.subckt  sky130_fd_pr__special_nfet_01v8 d g s b
++ 
+.param  l = 1 w = 1 nf = 1.0 ad = 0 as = 0 pd = 0 ps = 0 nrd = 0 nrs = 0 sa = 0 sb = 0 sd = 0 mult = 1
+msky130_fd_pr__special_nfet_01v8 d g s b sky130_fd_pr__special_nfet_01v8__model l = {l} w = {w} nf = {nf} ad = {ad} as = {as} pd = {pd} ps = {ps} nrd = {nrd} nrs = {nrs} sa = {sa} sb = {sb} sd = {sd}
+.model sky130_fd_pr__special_nfet_01v8__model.0 nmos
+* Model Flag Parameters
++ lmin = 1.5e-07 lmax = 1.8e-07 wmin = 3.9e-07 wmax = 4.2e-7
++ level = 54.0
++ version = 4.5
++ binunit = 2.0
++ mobmod = 0.0
++ capmod = 2.0
++ igcmod = 0.0
++ igbmod = 0.0
++ geomod = 0.0
++ diomod = 1.0
++ rdsmod = 0.0
++ rbodymod = 1.0
++ rgatemod = 0.0
++ permod = 1.0
++ acnqsmod = 0.0
++ trnqsmod = 0.0
++ fnoimod = 1.0
++ tnoimod = 1.0
++ tempmod = 0.0
+* Process Parameters
+*(mismatch parameter sky130_fd_pr__special_nfet_01v8__toxe_slope_spectre)
++ toxe = {3.932304e-09+MC_MM_SWITCH*AGAUSS(0,1.0,1)*(4.148e-9*0.948*(sky130_fd_pr__special_nfet_01v8__toxe_slope/sqrt(l*w*mult)))}
++ toxm = 4.148e-9
++ dtox = 0.0
++ epsrox = 3.9
++ xj = 1.5e-7
++ ngate = 1.0e+23
++ ndep = 1.7e+17
++ nsd = 1.0e+20
++ rsh = 1.0
++ rshg = 0.1
+* Basic Model Parameters
++ wint = -1.0316e-8
++ lint = 2.40595e-8
+*(mismatch parameter sky130_fd_pr__special_nfet_01v8__vth0_slope_spectre)
++ vth0 = {-3.035229047e+00+MC_MM_SWITCH*AGAUSS(0,1.0,1)*(sky130_fd_pr__special_nfet_01v8__vth0_slope/sqrt(l*w*mult))} lvth0 = 4.467942390e-07 wvth0 = 1.604969324e-06 pvth0 = -2.116649594e-13
++ k1 = 0.90707349
++ k2 = -1.512266114e+00 lk2 = 1.830822307e-07 wk2 = 5.861840111e-07 pk2 = -7.730653357e-14
++ k3 = 2.0
++ k3b = 0.54
++ w0 = 0.0
++ dvt0 = 0.0
++ dvt1 = 0.53
++ dvt2 = -0.032
++ dvt0w = -3.58
++ dvt1w = 1670600.0
++ dvt2w = 0.068
++ dsub = 3.213159080e+00 ldsub = -3.414964965e-07 wdsub = -1.140985314e-06 pdsub = 1.504742842e-13
++ minv = 0.0
++ voffl = 5.8197729e-9
++ lpe0 = 1.0325e-7
++ lpeb = -7.082e-8
++ vbm = -3.0
++ dvtp0 = 0.0
++ dvtp1 = 0.0
++ phin = 0.0
++ cdsc = 0.0
++ cdscb = 0.0
++ cdscd = 0.002052
++ cit = 0.0
+*(mismatch parameter sky130_fd_pr__special_nfet_01v8__voff_slope_spectre)
++ voff = {-0.20753+MC_MM_SWITCH*AGAUSS(0,1.0,1)*(sky130_fd_pr__special_nfet_01v8__voff_slope/sqrt(l*w*mult))}
++ nfactor = -6.688470453e+00 lnfactor = 1.088828059e-06 wnfactor = 1.671005367e-06 pnfactor = -2.203738588e-13
++ eta0 = 5.391586575e-04 leta0 = -7.110477581e-11 weta0 = -2.375705338e-10 peta0 = 3.133103957e-17
++ etab = -0.043998
++ u0 = 1.737752934e-01 lu0 = -1.963751524e-08 wu0 = -7.101431164e-08 pu0 = 9.365438434e-15
++ ua = -2.844196309e-09 lua = 2.236700849e-16 wua = 7.848996634e-16 pua = -1.035133525e-22
++ ub = 1.292471857e-17 lub = -1.383787580e-24 wub = -5.386702958e-24 pub = 7.104037728e-31
++ uc = -1.316563759e-10 luc = 2.942467889e-17 wuc = 1.330372550e-16 puc = -1.754508622e-23
++ ud = 0.0
++ up = 0.0
++ lp = 1.0
++ eu = 1.67
++ vtl = 0.0
++ xn = 3.0
++ vsat = 6.079825513e+05 lvsat = -5.527482872e-02 wvsat = -1.054266865e-01 pvsat = 1.390377685e-8
++ a0 = 1.5
++ ags = 1.25
++ a1 = 0.0
++ a2 = 0.42385546
++ b0 = -5.001055089e-06 lb0 = 8.007095686e-13 wb0 = 4.651170118e-12 pb0 = -6.134009663e-19
++ b1 = 8.433993044e-08 lb1 = -8.963019229e-15 wb1 = -3.961488857e-14 pb1 = 5.224451119e-21
++ keta = -9.616951609e-01 lketa = 1.178118243e-07 wketa = 4.295745452e-07 pketa = -5.665272059e-14
++ dwg = 0.0
++ dwb = 0.0
++ pclm = 1.592040983e-02 lpclm = 2.179064358e-08 wpclm = 1.287409127e-07 ppclm = -1.697848030e-14
++ pdiblc1 = 0.35697215
++ pdiblc2 = 0.0084061121
++ pdiblcb = -0.10329577
++ drout = 0.50332666
++ pscbe1 = 791419880.0
++ pscbe2 = 1.0e-12
++ pvag = 0.0
++ delta = 0.01
++ fprout = 0.0
++ pdits = 0.0
++ pditsl = 0.0
++ pditsd = 0.0
++ lambda = 0.0
++ lc = 5.0e-9
+* Parameters FOR Asymmetric AND Bias-Dependent RDS Model
++ rdsw = 65.968
++ rsw = 0.0
++ rdw = 0.0
++ rdswmin = 0.0
++ rdwmin = 0.0
++ rswmin = 0.0
++ prwb = 0.0
++ prwg = 0.021507
++ wr = 1.0
+* Impact Ionization Current Model Parameters
++ alpha0 = 1.249543125e-07 lalpha0 = -9.674040084e-15 walpha0 = 3.315074562e-21 palpha0 = -4.371953410e-28
++ alpha1 = 0.85
++ beta0 = 1.626781828e+01 lbeta0 = -2.463297428e-07 wbeta0 = 2.293410262e-14 pbeta0 = -3.024567263e-21
+* Gidl Induced Drain Leakage Model Parameters
++ agidl = 0.0
++ bgidl = 2300000000.0
++ cgidl = 0.5
++ egidl = 0.8
+* Gate Dielectric Tunneling Current Model Parameters
++ toxref = 4.148e-9
++ dlcig = 0.0
++ aigbacc = 1.0
++ bigbacc = 0.0
++ cigbacc = 0.0
++ nigbacc = 0.0
++ aigbinv = 0.35
++ bigbinv = 0.03
++ cigbinv = 0.006
++ eigbinv = 1.1
++ nigbinv = 0.0
++ aigc = 0.43
++ bigc = 0.054
++ cigc = 0.075
++ aigsd = 0.43
++ bigsd = 0.054
++ cigsd = 0.075
++ nigc = 0.0
++ poxedge = 1.0
++ pigcd = 1.0
++ ntox = 1.0
++ vfbsdoff = 0.0
+* Charge AND Capacitance Model Parameters
++ dlc = 2.3267e-8
++ dwc = -3.2175e-8
++ xpart = 0.0
++ cgso = 2.4083264e-10
++ cgdo = 2.4083264e-10
++ cgbo = 1.0e-13
++ cgdl = 0.0
++ cgsl = 0.0
++ clc = 1.0e-7
++ cle = 0.6
++ cf = 1.4067e-12
++ ckappas = 0.6
++ vfbcv = -1.0
++ acde = 0.4
++ moin = 6.9
++ noff = 3.4037
++ voffcv = -0.17287
+* High-Speed/RF Model Parameters
++ xrcrg1 = 12.0
++ xrcrg2 = 1.0
++ rbpb = 50.0
++ rbpd = 50.0
++ rbps = 50.0
++ rbdb = 50.0
++ rbsb = 50.0
++ gbmin = 1.0e-12
+* Flicker AND Thermal Noise Model Parameters
++ ef = 0.84
++ noia = 2.5e+42
++ noib = 0.0
++ noic = 0.0
++ em = 41000000.0
++ ntnoi = 1.0
++ lintnoi = -1.0e-7
++ af = 1.0
++ kf = 0.0
++ tnoia = 15000000.0
++ tnoib = 9900000.0
++ rnoia = 0.94
++ rnoib = 0.26
+* Layout-Dependent Parasitics Model Parameters
++ xl = 0.0
++ xw = 0.0
++ dmcg = 0.0
++ dmdg = 0.0
++ dmcgt = 0.0
++ xgw = 0.0
++ xgl = 0.0
++ ngcon = 1.0
+* Asymmetric Source/Drain Junction Diode Model Parameters
++ jss = 0.00275
++ jsws = 6.0e-10
++ ijthsfwd = 0.1
++ ijthsrev = 0.1
++ bvs = 11.7
++ xjbvs = 1.0
++ pbs = 0.729
++ cjs = 0.00104159201
++ mjs = 0.44
++ pbsws = 0.2
++ cjsws = 2.856175336e-11
++ mjsws = 0.0009
++ pbswgs = 0.95578
++ cjswgs = 1.852257592e-10
++ mjswgs = 0.8
+* Temperature Dependence Parameters
++ tnom = 30.0
++ kt1 = -1.530400707e-01 lkt1 = -8.957445783e-09 wkt1 = -1.142115735e-15 pkt1 = 1.506234026e-22
++ kt2 = -0.028878939
++ at = 9.760154499e+03 lat = 4.478722611e-03 wat = -3.668076824e-10 pat = 4.837499000e-17
++ ute = -9.181979405e-01 lute = -4.758863367e-08 wute = -2.487840260e-07 pute = 3.280988613e-14
++ ua1 = -2.3847336e-11
++ ub1 = 7.0775317e-19
++ uc1 = 1.4718625e-10
++ kt1l = 0.0
++ prt = 0.0
++ tvoff = 0.0
++ njs = 1.2928
++ tpb = 0.0012287
++ tcj = 0.000792
++ tpbsw = 0.0
++ tcjsw = 1.0e-5
++ tpbswg = 0.0
++ tcjswg = 0.0
++ xtis = 2.0
++ tvfbsdoff = 0.0
+* DW AND DL Parameters
++ ll = 0.0
++ wl = 0.0
++ lln = 1.0
++ wln = 1.0
++ lw = 0.0
++ ww = 0.0
++ lwn = 1.0
++ wwn = 1.0
++ lwl = 0.0
++ wwl = 0.0
++ llc = 0.0
++ wlc = 0.0
++ lwc = 0.0
++ wwc = 0.0
++ lwlc = 0.0
++ wwlc = 0.0
+* Stress Parameters
++ saref = 1.04e-6
++ sbref = 1.04e-6
++ kvth0 = 9.8e-9
++ lkvth0 = 0.0
++ wkvth0 = 2.0e-7
++ pkvth0 = 0.0
++ llodvth = 0.0
++ wlodvth = 1.0
++ wlod = 0.0
++ stk2 = 0.0
++ lodk2 = 1.0
++ lodeta0 = 1.0
++ ku0 = -2.7e-8
++ lku0 = 0.0
++ wku0 = 0.0
++ pku0 = 0.0
++ tku0 = 0.0
++ llodku0 = 0.0
++ wlodku0 = 1.0
++ kvsat = 0.2
++ steta0 = 0.0
+* Well Proximity Effect Parameters
+.model sky130_fd_pr__special_nfet_01v8__model.1 nmos
+* Model Flag Parameters
++ lmin = 1.5e-07 lmax = 1.8e-07 wmin = 3.6e-07 wmax = 3.9e-7
++ level = 54.0
++ version = 4.5
++ binunit = 2.0
++ mobmod = 0.0
++ capmod = 2.0
++ igcmod = 0.0
++ igbmod = 0.0
++ geomod = 0.0
++ diomod = 1.0
++ rdsmod = 0.0
++ rbodymod = 1.0
++ rgatemod = 0.0
++ permod = 1.0
++ acnqsmod = 0.0
++ trnqsmod = 0.0
++ fnoimod = 1.0
++ tnoimod = 1.0
++ tempmod = 0.0
+* Process Parameters
+*(mismatch parameter sky130_fd_pr__special_nfet_01v8__toxe_slope_spectre)
++ toxe = {3.932304e-09+MC_MM_SWITCH*AGAUSS(0,1.0,1)*(4.148e-9*0.948*(sky130_fd_pr__special_nfet_01v8__toxe_slope/sqrt(l*w*mult)))}
++ toxm = 4.148e-9
++ dtox = 0.0
++ epsrox = 3.9
++ xj = 1.5e-7
++ ngate = 1.0e+23
++ ndep = 1.7e+17
++ nsd = 1.0e+20
++ rsh = 1.0
++ rshg = 0.1
+* Basic Model Parameters
++ wint = -1.0316e-8
++ lint = 2.40595e-8
+*(mismatch parameter sky130_fd_pr__special_nfet_01v8__vth0_slope_spectre)
++ vth0 = {-3.045170427e-01+MC_MM_SWITCH*AGAUSS(0,1.0,1)*(sky130_fd_pr__special_nfet_01v8__vth0_slope/sqrt(l*w*mult))} lvth0 = 8.666520914e-08 wvth0 = 4.836515918e-07 pvth0 = -6.378445558e-14
++ k1 = 0.90707349
++ k2 = -4.744370369e-01 lk2 = 4.621229419e-08 wk2 = 1.600181815e-07 pk2 = -2.110335779e-14
++ k3 = 2.0
++ k3b = 0.54
++ w0 = 0.0
++ dvt0 = 0.0
++ dvt1 = 0.53
++ dvt2 = -0.032
++ dvt0w = -3.58
++ dvt1w = 1670600.0
++ dvt2w = 0.068
++ dsub = 3.290138835e+00 ldsub = -3.516486635e-07 wdsub = -1.172595665e-06 pdsub = 1.546430889e-13
++ minv = 0.0
++ voffl = 5.8197729e-9
++ lpe0 = 1.0325e-7
++ lpeb = -7.082e-8
++ vbm = -3.0
++ dvtp0 = 0.0
++ dvtp1 = 0.0
++ phin = 0.0
++ cdsc = 0.0
++ cdscb = 0.0
++ cdscd = 0.002052
++ cit = 0.0
+*(mismatch parameter sky130_fd_pr__special_nfet_01v8__voff_slope_spectre)
++ voff = {-0.20753+MC_MM_SWITCH*AGAUSS(0,1.0,1)*(sky130_fd_pr__special_nfet_01v8__voff_slope/sqrt(l*w*mult))}
++ nfactor = -6.688470389e+00 lnfactor = 1.088828051e-06 wnfactor = 1.671005340e-06 pnfactor = -2.203738553e-13
++ eta0 = 8.627946104e-04 leta0 = -1.137862046e-10 weta0 = -3.704657991e-10 peta0 = 4.885740006e-17
++ etab = -0.043998
++ u0 = 7.747248961e-02 lu0 = -6.937005170e-09 wu0 = -3.146929871e-08 pu0 = 4.150202584e-15
++ ua = -2.844194477e-09 lua = 2.236698432e-16 wua = 7.848989109e-16 pua = -1.035132533e-22
++ ub = 1.292468824e-17 lub = -1.383783580e-24 wub = -5.386690503e-24 pub = 7.104021303e-31
++ uc = -1.406321093e-10 luc = 3.060840758e-17 wuc = 1.367229783e-16 puc = -1.803116311e-23
++ ud = 0.0
++ up = 0.0
++ lp = 1.0
++ eu = 1.67
++ vtl = 0.0
++ xn = 3.0
++ vsat = 3.059330551e+05 lvsat = -1.544023911e-02 wvsat = 1.860450219e-02 pvsat = -2.453580354e-9
++ a0 = 1.5
++ ags = 1.25
++ a1 = 0.0
++ a2 = 0.42385546
++ b0 = -5.001032725e-06 lb0 = 8.007066192e-13 wb0 = 4.651160935e-12 pb0 = -6.133997552e-19
++ b1 = 8.433660613e-08 lb1 = -8.962580816e-15 wb1 = -3.961352350e-14 pb1 = 5.224271092e-21
++ keta = -9.616948578e-01 lketa = 1.178117843e-07 wketa = 4.295744207e-07 pketa = -5.665270418e-14
++ dwg = 0.0
++ dwb = 0.0
++ pclm = 1.592022520e-02 lpclm = 2.179066793e-08 wpclm = 1.287409885e-07 ppclm = -1.697849030e-14
++ pdiblc1 = 0.35697215
++ pdiblc2 = 0.0084061121
++ pdiblcb = -0.10329577
++ drout = 0.50332666
++ pscbe1 = 791419880.0
++ pscbe2 = 1.0e-12
++ pvag = 0.0
++ delta = 0.01
++ fprout = 0.0
++ pdits = 0.0
++ pditsl = 0.0
++ pditsd = 0.0
++ lambda = 0.0
++ lc = 5.0e-9
+* Parameters FOR Asymmetric AND Bias-Dependent RDS Model
++ rdsw = 65.968
++ rsw = 0.0
++ rdw = 0.0
++ rdswmin = 0.0
++ rdwmin = 0.0
++ rswmin = 0.0
++ prwb = 0.0
++ prwg = 0.021507
++ wr = 1.0
+* Impact Ionization Current Model Parameters
++ alpha0 = 1.249543199e-07 lalpha0 = -9.674041067e-15 walpha0 = 2.526371056e-22 palpha0 = -3.331806745e-29
++ alpha1 = 0.85
++ beta0 = 1.626781834e+01 lbeta0 = -2.463297501e-07 wbeta0 = 4.422417987e-17 pbeta0 = -5.826450433e-24
+* Gidl Induced Drain Leakage Model Parameters
++ agidl = 0.0
++ bgidl = 2300000000.0
++ cgidl = 0.5
++ egidl = 0.8
+* Gate Dielectric Tunneling Current Model Parameters
++ toxref = 4.148e-9
++ dlcig = 0.0
++ aigbacc = 1.0
++ bigbacc = 0.0
++ cigbacc = 0.0
++ nigbacc = 0.0
++ aigbinv = 0.35
++ bigbinv = 0.03
++ cigbinv = 0.006
++ eigbinv = 1.1
++ nigbinv = 0.0
++ aigc = 0.43
++ bigc = 0.054
++ cigc = 0.075
++ aigsd = 0.43
++ bigsd = 0.054
++ cigsd = 0.075
++ nigc = 0.0
++ poxedge = 1.0
++ pigcd = 1.0
++ ntox = 1.0
++ vfbsdoff = 0.0
+* Charge AND Capacitance Model Parameters
++ dlc = 2.3267e-8
++ dwc = -3.2175e-8
++ xpart = 0.0
++ cgso = 2.4083264e-10
++ cgdo = 2.4083264e-10
++ cgbo = 1.0e-13
++ cgdl = 0.0
++ cgsl = 0.0
++ clc = 1.0e-7
++ cle = 0.6
++ cf = 1.4067e-12
++ ckappas = 0.6
++ vfbcv = -1.0
++ acde = 0.4
++ moin = 6.9
++ noff = 3.4037
++ voffcv = -0.17287
+* High-Speed/RF Model Parameters
++ xrcrg1 = 12.0
++ xrcrg2 = 1.0
++ rbpb = 50.0
++ rbpd = 50.0
++ rbps = 50.0
++ rbdb = 50.0
++ rbsb = 50.0
++ gbmin = 1.0e-12
+* Flicker AND Thermal Noise Model Parameters
++ ef = 0.84
++ noia = 2.5e+42
++ noib = 0.0
++ noic = 0.0
++ em = 41000000.0
++ ntnoi = 1.0
++ lintnoi = -1.0e-7
++ af = 1.0
++ kf = 0.0
++ tnoia = 15000000.0
++ tnoib = 9900000.0
++ rnoia = 0.94
++ rnoib = 0.26
+* Layout-Dependent Parasitics Model Parameters
++ xl = 0.0
++ xw = 0.0
++ dmcg = 0.0
++ dmdg = 0.0
++ dmcgt = 0.0
++ xgw = 0.0
++ xgl = 0.0
++ ngcon = 1.0
+* Asymmetric Source/Drain Junction Diode Model Parameters
++ jss = 0.00275
++ jsws = 6.0e-10
++ ijthsfwd = 0.1
++ ijthsrev = 0.1
++ bvs = 11.7
++ xjbvs = 1.0
++ pbs = 0.729
++ cjs = 0.00104159201
++ mjs = 0.44
++ pbsws = 0.2
++ cjsws = 2.856175336e-11
++ mjsws = 0.0009
++ pbswgs = 0.95578
++ cjswgs = 1.852257592e-10
++ mjswgs = 0.8
+* Temperature Dependence Parameters
++ tnom = 30.0
++ kt1 = -1.530400733e-01 lkt1 = -8.957445446e-09 wkt1 = -9.402256751e-17 pkt1 = 1.239974790e-23
++ kt2 = -0.028878939
++ at = 9.760153678e+03 lat = 4.478722719e-03 wat = -2.983096056e-11 pat = 3.934124834e-18
++ ute = -9.014130388e-01 lute = -4.980224329e-08 wute = -2.556764437e-07 pute = 3.371886508e-14
++ ua1 = -2.3847336e-11
++ ub1 = 7.0775317e-19
++ uc1 = 1.4718625e-10
++ kt1l = 0.0
++ prt = 0.0
++ tvoff = 0.0
++ njs = 1.2928
++ tpb = 0.0012287
++ tcj = 0.000792
++ tpbsw = 0.0
++ tcjsw = 1.0e-5
++ tpbswg = 0.0
++ tcjswg = 0.0
++ xtis = 2.0
++ tvfbsdoff = 0.0
+* DW AND DL Parameters
++ ll = 0.0
++ wl = 0.0
++ lln = 1.0
++ wln = 1.0
++ lw = 0.0
++ ww = 0.0
++ lwn = 1.0
++ wwn = 1.0
++ lwl = 0.0
++ wwl = 0.0
++ llc = 0.0
++ wlc = 0.0
++ lwc = 0.0
++ wwc = 0.0
++ lwlc = 0.0
++ wwlc = 0.0
+* Stress Parameters
++ saref = 1.04e-6
++ sbref = 1.04e-6
++ kvth0 = 9.8e-9
++ lkvth0 = 0.0
++ wkvth0 = 2.0e-7
++ pkvth0 = 0.0
++ llodvth = 0.0
++ wlodvth = 1.0
++ wlod = 0.0
++ stk2 = 0.0
++ lodk2 = 1.0
++ lodeta0 = 1.0
++ ku0 = -2.7e-8
++ lku0 = 0.0
++ wku0 = 0.0
++ pku0 = 0.0
++ tku0 = 0.0
++ llodku0 = 0.0
++ wlodku0 = 1.0
++ kvsat = 0.2
++ steta0 = 0.0
+.ends sky130_fd_pr__special_nfet_01v8
+* Well Proximity Effect Parameters

--- a/cells/special_nfet_01v8/sky130_fd_pr__special_nfet_01v8__ss.corner.spice
+++ b/cells/special_nfet_01v8/sky130_fd_pr__special_nfet_01v8__ss.corner.spice
@@ -1,0 +1,72 @@
+* Copyright 2020 The SkyWater PDK Authors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+
+* SKY130 Spice File.
+* Number of bins: 2
+.param
++ sky130_fd_pr__special_nfet_01v8__toxe_mult = 1.0365
++ sky130_fd_pr__special_nfet_01v8__rshn_mult = 1.0
++ sky130_fd_pr__special_nfet_01v8__overlap_mult = 0.98
++ sky130_fd_pr__special_nfet_01v8__lint_diff = -1.21275e-8
++ sky130_fd_pr__special_nfet_01v8__wint_diff = 2.252e-8
++ sky130_fd_pr__special_nfet_01v8__dlc_diff = -11.107e-9
++ sky130_fd_pr__special_nfet_01v8__dwc_diff = 2.252e-8
+*
+* sky130_fd_pr__special_nfet_01v8, Bin 000, W = 0.36, L = 0.15
+* -----------------------------------
++ sky130_fd_pr__special_nfet_01v8__ub_diff_0 = -1.32884e-18
++ sky130_fd_pr__special_nfet_01v8__eta0_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__tvoff_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__rdsw_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__a0_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__vsat_diff_0 = 31459.0
++ sky130_fd_pr__special_nfet_01v8__kt1_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__vth0_diff_0 = 0.14691
++ sky130_fd_pr__special_nfet_01v8__pdits_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__b0_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__b1_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__voff_diff_0 = 0.0112789
++ sky130_fd_pr__special_nfet_01v8__pditsd_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__pclm_diff_0 = -0.00090237
++ sky130_fd_pr__special_nfet_01v8__u0_diff_0 = -0.017871
++ sky130_fd_pr__special_nfet_01v8__nfactor_diff_0 = 0.55976134
++ sky130_fd_pr__special_nfet_01v8__keta_diff_0 = -0.00301097
++ sky130_fd_pr__special_nfet_01v8__ags_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__k2_diff_0 = 0.0084041
++ sky130_fd_pr__special_nfet_01v8__ua_diff_0 = -9.72898e-11
+*
+* sky130_fd_pr__special_nfet_01v8, Bin 001, W = 0.39, L = 0.15
+* -----------------------------------
++ sky130_fd_pr__special_nfet_01v8__ua_diff_1 = -4.01828e-11
++ sky130_fd_pr__special_nfet_01v8__ub_diff_1 = -9.60681e-19
++ sky130_fd_pr__special_nfet_01v8__eta0_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__tvoff_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__a0_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__rdsw_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__vsat_diff_1 = 37070.0
++ sky130_fd_pr__special_nfet_01v8__kt1_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__vth0_diff_1 = 0.13857
++ sky130_fd_pr__special_nfet_01v8__pdits_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__b0_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__b1_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__voff_diff_1 = 0.00507783
++ sky130_fd_pr__special_nfet_01v8__pditsd_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__pclm_diff_1 = -0.00031247
++ sky130_fd_pr__special_nfet_01v8__u0_diff_1 = -0.012893
++ sky130_fd_pr__special_nfet_01v8__nfactor_diff_1 = 0.17556582
++ sky130_fd_pr__special_nfet_01v8__keta_diff_1 = -0.00104263
++ sky130_fd_pr__special_nfet_01v8__ags_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__k2_diff_1 = 0.00316
+*
+.include "sky130_fd_pr__special_nfet_01v8__ss.pm3.spice"

--- a/cells/special_nfet_01v8/sky130_fd_pr__special_nfet_01v8__ss.pm3.spice
+++ b/cells/special_nfet_01v8/sky130_fd_pr__special_nfet_01v8__ss.pm3.spice
@@ -1,0 +1,574 @@
+* Copyright 2020 The SkyWater PDK Authors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+
+* SKY130 Spice File.
+.param sky130_fd_pr__special_nfet_01v8__toxe_slope_spectre = 0.0
+.param sky130_fd_pr__special_nfet_01v8__vth0_slope_spectre = 0.0
+.param sky130_fd_pr__special_nfet_01v8__voff_slope_spectre = 0.0
+* statistics {
+*   process {
+*   }
+*   mismatch {
+*     vary sky130_fd_pr__special_nfet_01v8__toxe_slope_spectre dist=gauss std = 1.0
+*     vary sky130_fd_pr__special_nfet_01v8__vth0_slope_spectre dist=gauss std = 1.0
+*     vary sky130_fd_pr__special_nfet_01v8__voff_slope_spectre dist=gauss std = 1.0
+*   }
+* }
+.subckt  sky130_fd_pr__special_nfet_01v8 d g s b
++ 
+.param  l = 1 w = 1 nf = 1.0 ad = 0 as = 0 pd = 0 ps = 0 nrd = 0 nrs = 0 sa = 0 sb = 0 sd = 0 mult = 1
+msky130_fd_pr__special_nfet_01v8 d g s b sky130_fd_pr__special_nfet_01v8__model l = {l} w = {w} nf = {nf} ad = {ad} as = {as} pd = {pd} ps = {ps} nrd = {nrd} nrs = {nrs} sa = {sa} sb = {sb} sd = {sd}
+.model sky130_fd_pr__special_nfet_01v8__model.0 nmos
+* Model Flag Parameters
++ lmin = 1.5e-07 lmax = 1.8e-07 wmin = 3.9e-07 wmax = 4.2e-7
++ level = 54.0
++ version = 4.5
++ binunit = 2.0
++ mobmod = 0.0
++ capmod = 2.0
++ igcmod = 0.0
++ igbmod = 0.0
++ geomod = 0.0
++ diomod = 1.0
++ rdsmod = 0.0
++ rbodymod = 1.0
++ rgatemod = 0.0
++ permod = 1.0
++ acnqsmod = 0.0
++ trnqsmod = 0.0
++ fnoimod = 1.0
++ tnoimod = 1.0
++ tempmod = 0.0
+* Process Parameters
+*(mismatch parameter sky130_fd_pr__special_nfet_01v8__toxe_slope_spectre)
++ toxe = {4.299402e-09+MC_MM_SWITCH*AGAUSS(0,1.0,1)*(4.148e-9*1.0365*(sky130_fd_pr__special_nfet_01v8__toxe_slope/sqrt(l*w*mult)))}
++ toxm = 4.148e-9
++ dtox = 0.0
++ epsrox = 3.9
++ xj = 1.5e-7
++ ngate = 1.0e+23
++ ndep = 1.7e+17
++ nsd = 1.0e+20
++ rsh = 1.0
++ rshg = 0.1
+* Basic Model Parameters
++ wint = 4.4379e-8
++ lint = -1.955e-10
+*(mismatch parameter sky130_fd_pr__special_nfet_01v8__vth0_slope_spectre)
++ vth0 = {-6.434254564e-01+MC_MM_SWITCH*AGAUSS(0,1.0,1)*(sky130_fd_pr__special_nfet_01v8__vth0_slope/sqrt(l*w*mult))} lvth0 = 2.048180802e-07 wvth0 = 3.791454863e-07 pvth0 = -6.839443341e-14
++ k1 = 0.90707349
++ k2 = -1.051417275e-01 lk2 = -8.143440074e-09 wk2 = -6.919717345e-09 pk2 = 1.248254732e-15
++ k3 = 2.0
++ k3b = 0.54
++ w0 = 0.0
++ dvt0 = 0.0
++ dvt1 = 0.53
++ dvt2 = -0.032
++ dvt0w = -3.58
++ dvt1w = 1670600.0
++ dvt2w = 0.068
++ dsub = 3.427842290e+00 ldsub = -5.058366201e-07 wdsub = -9.288397632e-07 pdsub = 1.675543337e-13
++ minv = 0.0
++ voffl = 5.8197729e-9
++ lpe0 = 1.0325e-7
++ lpeb = -7.082e-8
++ vbm = -3.0
++ dvtp0 = 0.0
++ dvtp1 = 0.0
++ phin = 0.0
++ cdsc = 0.0
++ cdscb = 0.0
++ cdscd = 0.002052
++ cit = 0.0
+*(mismatch parameter sky130_fd_pr__special_nfet_01v8__voff_slope_spectre)
++ voff = {4.807716122e-02+MC_MM_SWITCH*AGAUSS(0,1.0,1)*(sky130_fd_pr__special_nfet_01v8__voff_slope/sqrt(l*w*mult))} lvoff = -4.610923142e-08 wvoff = -8.466782730e-08 pvoff = 1.527331403e-14
++ nfactor = 2.491112224e+00 lnfactor = -3.654346851e-07 wnfactor = -3.550381611e-06 pnfactor = 6.404568892e-13
++ eta0 = 0.0
++ etab = -0.043998
++ u0 = 3.623981224e-02 lu0 = -2.903359274e-09 wu0 = -1.421460009e-08 pu0 = 2.564185925e-15
++ ua = -3.646487008e-09 lua = 4.509271723e-16 wua = 9.041211891e-16 pua = -1.630953254e-22
++ ub = -8.982807731e-18 lub = 1.879087540e-24 wub = 2.375837577e-24 pub = -4.285797164e-31
++ uc = -1.191640290e-10 luc = 3.799449883e-17 wuc = 1.083013873e-16 puc = -1.953659556e-23
++ ud = 0.0
++ up = 0.0
++ lp = 1.0
++ eu = 1.67
++ vtl = 0.0
++ xn = 3.0
++ vsat = -9.854663233e+05 lvsat = 2.191624960e-01 wvsat = 3.541528011e-01 pvsat = -6.388597795e-8
++ a0 = 1.5
++ ags = 1.25
++ a1 = 0.0
++ a2 = 0.42385546
++ b0 = 0.0
++ b1 = 0.0
++ keta = -1.111168377e+00 lketa = 1.881103596e-07 wketa = 3.853091375e-07 pketa = -6.950630063e-14
++ dwg = 0.0
++ dwb = 0.0
++ pclm = 1.992526528e-02 lpclm = 2.908349112e-08 wpclm = 1.154749098e-07 ppclm = -2.083063446e-14
++ pdiblc1 = 0.35697215
++ pdiblc2 = 0.0084061121
++ pdiblcb = -0.10329577
++ drout = 0.50332666
++ pscbe1 = 791419880.0
++ pscbe2 = 1.0e-12
++ pvag = 0.0
++ delta = 0.01
++ fprout = 0.0
++ pdits = 0.0
++ pditsl = 0.0
++ pditsd = 0.0
++ lambda = 0.0
++ lc = 5.0e-9
+* Parameters FOR Asymmetric AND Bias-Dependent RDS Model
++ rdsw = 65.968
++ rsw = 0.0
++ rdw = 0.0
++ rdswmin = 0.0
++ rdwmin = 0.0
++ rswmin = 0.0
++ prwb = 0.0
++ prwg = 0.021507
++ wr = 1.0
+* Impact Ionization Current Model Parameters
++ alpha0 = 1.598815119e-07 lalpha0 = -1.953301020e-14 walpha0 = 2.698696521e-21 palpha0 = -4.868205662e-28
++ alpha1 = 0.85
++ beta0 = 1.715716828e+01 lbeta0 = -4.973683427e-07 wbeta0 = 1.866987986e-14 pbeta0 = -3.367880197e-21
+* Gidl Induced Drain Leakage Model Parameters
++ agidl = 0.0
++ bgidl = 2300000000.0
++ cgidl = 0.5
++ egidl = 0.8
+* Gate Dielectric Tunneling Current Model Parameters
++ toxref = 4.148e-9
++ dlcig = 0.0
++ aigbacc = 1.0
++ bigbacc = 0.0
++ cigbacc = 0.0
++ nigbacc = 0.0
++ aigbinv = 0.35
++ bigbinv = 0.03
++ cigbinv = 0.006
++ eigbinv = 1.1
++ nigbinv = 0.0
++ aigc = 0.43
++ bigc = 0.054
++ cigc = 0.075
++ aigsd = 0.43
++ bigsd = 0.054
++ cigsd = 0.075
++ nigc = 0.0
++ poxedge = 1.0
++ pigcd = 1.0
++ ntox = 1.0
++ vfbsdoff = 0.0
+* Charge AND Capacitance Model Parameters
++ dlc = -6.13e-10
++ dwc = 2.252e-8
++ xpart = 0.0
++ cgso = 2.4892e-10
++ cgdo = 2.4892e-10
++ cgbo = 1.0e-13
++ cgdl = 0.0
++ cgsl = 0.0
++ clc = 1.0e-7
++ cle = 0.6
++ cf = 1.4067e-12
++ ckappas = 0.6
++ vfbcv = -1.0
++ acde = 0.4
++ moin = 6.9
++ noff = 3.4037
++ voffcv = -0.17287
+* High-Speed/RF Model Parameters
++ xrcrg1 = 12.0
++ xrcrg2 = 1.0
++ rbpb = 50.0
++ rbpd = 50.0
++ rbps = 50.0
++ rbdb = 50.0
++ rbsb = 50.0
++ gbmin = 1.0e-12
+* Flicker AND Thermal Noise Model Parameters
++ ef = 0.84
++ noia = 2.5e+42
++ noib = 0.0
++ noic = 0.0
++ em = 41000000.0
++ ntnoi = 1.0
++ lintnoi = -1.0e-7
++ af = 1.0
++ kf = 0.0
++ tnoia = 15000000.0
++ tnoib = 9900000.0
++ rnoia = 0.94
++ rnoib = 0.26
+* Layout-Dependent Parasitics Model Parameters
++ xl = 0.0
++ xw = 0.0
++ dmcg = 0.0
++ dmdg = 0.0
++ dmcgt = 0.0
++ xgw = 0.0
++ xgl = 0.0
++ ngcon = 1.0
+* Asymmetric Source/Drain Junction Diode Model Parameters
++ jss = 0.00275
++ jsws = 6.0e-10
++ ijthsfwd = 0.1
++ ijthsrev = 0.1
++ bvs = 11.7
++ xjbvs = 1.0
++ pbs = 0.729
++ cjs = 0.00154845795
++ mjs = 0.44
++ pbsws = 0.2
++ cjsws = 4.24559793e-11
++ mjsws = 0.0009
++ pbswgs = 0.95578
++ cjswgs = 2.75331171e-10
++ mjswgs = 0.8
+* Temperature Dependence Parameters
++ tnom = 30.0
++ kt1 = -1.207000705e-01 lkt1 = -1.808612243e-08 wkt1 = -9.297602688e-16 pkt1 = 1.677203931e-22
++ kt2 = -0.028878939
++ at = -6.409845432e+03 lat = 9.043060798e-03 wat = -2.986065811e-10 pat = 5.386595149e-17
++ ute = -9.684077382e-01 lute = -5.603584160e-08 wute = -2.025271429e-07 pute = 3.653407383e-14
++ ua1 = -2.3847336e-11
++ ub1 = 7.0775317e-19
++ uc1 = 1.4718625e-10
++ kt1l = 0.0
++ prt = 0.0
++ tvoff = 0.0
++ njs = 1.2928
++ tpb = 0.0012287
++ tcj = 0.000792
++ tpbsw = 0.0
++ tcjsw = 1.0e-5
++ tpbswg = 0.0
++ tcjswg = 0.0
++ xtis = 2.0
++ tvfbsdoff = 0.0
+* DW AND DL Parameters
++ ll = 0.0
++ wl = 0.0
++ lln = 1.0
++ wln = 1.0
++ lw = 0.0
++ ww = 0.0
++ lwn = 1.0
++ wwn = 1.0
++ lwl = 0.0
++ wwl = 0.0
++ llc = 0.0
++ wlc = 0.0
++ lwc = 0.0
++ wwc = 0.0
++ lwlc = 0.0
++ wwlc = 0.0
+* Stress Parameters
++ saref = 1.04e-6
++ sbref = 1.04e-6
++ kvth0 = 9.8e-9
++ lkvth0 = 0.0
++ wkvth0 = 2.0e-7
++ pkvth0 = 0.0
++ llodvth = 0.0
++ wlodvth = 1.0
++ wlod = 0.0
++ stk2 = 0.0
++ lodk2 = 1.0
++ lodeta0 = 1.0
++ ku0 = -2.7e-8
++ lku0 = 0.0
++ wku0 = 0.0
++ pku0 = 0.0
++ tku0 = 0.0
++ llodku0 = 0.0
++ wlodku0 = 1.0
++ kvsat = 0.2
++ steta0 = 0.0
+* Well Proximity Effect Parameters
+.model sky130_fd_pr__special_nfet_01v8__model.1 nmos
+* Model Flag Parameters
++ lmin = 1.5e-07 lmax = 1.8e-07 wmin = 3.6e-07 wmax = 3.9e-7
++ level = 54.0
++ version = 4.5
++ binunit = 2.0
++ mobmod = 0.0
++ capmod = 2.0
++ igcmod = 0.0
++ igbmod = 0.0
++ geomod = 0.0
++ diomod = 1.0
++ rdsmod = 0.0
++ rbodymod = 1.0
++ rgatemod = 0.0
++ permod = 1.0
++ acnqsmod = 0.0
++ trnqsmod = 0.0
++ fnoimod = 1.0
++ tnoimod = 1.0
++ tempmod = 0.0
+* Process Parameters
+*(mismatch parameter sky130_fd_pr__special_nfet_01v8__toxe_slope_spectre)
++ toxe = {4.299402e-09+MC_MM_SWITCH*AGAUSS(0,1.0,1)*(4.148e-9*1.0365*(sky130_fd_pr__special_nfet_01v8__toxe_slope/sqrt(l*w*mult)))}
++ toxm = 4.148e-9
++ dtox = 0.0
++ epsrox = 3.9
++ xj = 1.5e-7
++ ngate = 1.0e+23
++ ndep = 1.7e+17
++ nsd = 1.0e+20
++ rsh = 1.0
++ rshg = 0.1
+* Basic Model Parameters
++ wint = 4.4379e-8
++ lint = -1.955e-10
+*(mismatch parameter sky130_fd_pr__special_nfet_01v8__vth0_slope_spectre)
++ vth0 = {-5.761948103e-01+MC_MM_SWITCH*AGAUSS(0,1.0,1)*(sky130_fd_pr__special_nfet_01v8__vth0_slope/sqrt(l*w*mult))} lvth0 = 1.926902767e-07 wvth0 = 3.588927920e-07 pvth0 = -6.474102964e-14
++ k1 = 0.90707349
++ k2 = -2.127292966e-01 lk2 = 1.126438910e-08 wk2 = 2.549017715e-08 pk2 = -4.598198546e-15
++ k3 = 2.0
++ k3b = 0.54
++ w0 = 0.0
++ dvt0 = 0.0
++ dvt1 = 0.53
++ dvt2 = -0.032
++ dvt0w = -3.58
++ dvt1w = 1670600.0
++ dvt2w = 0.068
++ dsub = 3.348307880e+00 ldsub = -4.914893283e-07 wdsub = -9.048806583e-07 pdsub = 1.632323268e-13
++ minv = 0.0
++ voffl = 5.8197729e-9
++ lpe0 = 1.0325e-7
++ lpeb = -7.082e-8
++ vbm = -3.0
++ dvtp0 = 0.0
++ dvtp1 = 0.0
++ phin = 0.0
++ cdsc = 0.0
++ cdscb = 0.0
++ cdscd = 0.002052
++ cit = 0.0
+*(mismatch parameter sky130_fd_pr__special_nfet_01v8__voff_slope_spectre)
++ voff = {4.807717192e-02+MC_MM_SWITCH*AGAUSS(0,1.0,1)*(sky130_fd_pr__special_nfet_01v8__voff_slope/sqrt(l*w*mult))} lvoff = -4.610923335e-08 wvoff = -8.466783052e-08 pvoff = 1.527331462e-14
++ nfactor = 2.491112037e+00 lnfactor = -3.654346514e-07 wnfactor = -3.550381555e-06 pnfactor = 6.404568790e-13
++ eta0 = 0.0
++ etab = -0.043998
++ u0 = -1.079238621e-01 lu0 = 2.310247010e-08 wu0 = 2.921355350e-08 pu0 = -5.269862129e-15
++ ua = -3.646487209e-09 lua = 4.509272086e-16 wua = 9.041212498e-16 pua = -1.630953364e-22
++ ub = -8.982836031e-18 lub = 1.879092645e-24 wub = 2.375846103e-24 pub = -4.285812543e-31
++ uc = -1.098904349e-10 luc = 3.632162591e-17 wuc = 1.055077913e-16 puc = -1.903265597e-23
++ ud = 0.0
++ up = 0.0
++ lp = 1.0
++ eu = 1.67
++ vtl = 0.0
++ xn = 3.0
++ vsat = 1.545278688e+05 lvsat = 1.351780364e-02 wvsat = 1.073867070e-02 pvsat = -1.937159546e-9
++ a0 = 1.5
++ ags = 1.25
++ a1 = 0.0
++ a2 = 0.42385546
++ b0 = 0.0
++ b1 = 0.0
++ keta = -1.111168044e+00 lketa = 1.881102996e-07 wketa = 3.853090373e-07 pketa = -6.950628255e-14
++ dwg = 0.0
++ dwb = 0.0
++ pclm = 1.992536747e-02 lpclm = 2.908347269e-08 wpclm = 1.154748791e-07 ppclm = -2.083062891e-14
++ pdiblc1 = 0.35697215
++ pdiblc2 = 0.0084061121
++ pdiblcb = -0.10329577
++ drout = 0.50332666
++ pscbe1 = 791419880.0
++ pscbe2 = 1.0e-12
++ pvag = 0.0
++ delta = 0.01
++ fprout = 0.0
++ pdits = 0.0
++ pditsl = 0.0
++ pditsd = 0.0
++ lambda = 0.0
++ lc = 5.0e-9
+* Parameters FOR Asymmetric AND Bias-Dependent RDS Model
++ rdsw = 65.968
++ rsw = 0.0
++ rdw = 0.0
++ rdswmin = 0.0
++ rdwmin = 0.0
++ rswmin = 0.0
++ prwb = 0.0
++ prwg = 0.021507
++ wr = 1.0
+* Impact Ionization Current Model Parameters
++ alpha0 = 1.598815202e-07 lalpha0 = -1.953301170e-14 walpha0 = 1.949577618e-22 palpha0 = -3.516859621e-29
++ alpha1 = 0.85
++ beta0 = 1.715716834e+01 lbeta0 = -4.973683538e-07 wbeta0 = 3.410605132e-17 pbeta0 = -6.153300092e-24
+* Gidl Induced Drain Leakage Model Parameters
++ agidl = 0.0
++ bgidl = 2300000000.0
++ cgidl = 0.5
++ egidl = 0.8
+* Gate Dielectric Tunneling Current Model Parameters
++ toxref = 4.148e-9
++ dlcig = 0.0
++ aigbacc = 1.0
++ bigbacc = 0.0
++ cigbacc = 0.0
++ nigbacc = 0.0
++ aigbinv = 0.35
++ bigbinv = 0.03
++ cigbinv = 0.006
++ eigbinv = 1.1
++ nigbinv = 0.0
++ aigc = 0.43
++ bigc = 0.054
++ cigc = 0.075
++ aigsd = 0.43
++ bigsd = 0.054
++ cigsd = 0.075
++ nigc = 0.0
++ poxedge = 1.0
++ pigcd = 1.0
++ ntox = 1.0
++ vfbsdoff = 0.0
+* Charge AND Capacitance Model Parameters
++ dlc = -6.13e-10
++ dwc = 2.252e-8
++ xpart = 0.0
++ cgso = 2.4892e-10
++ cgdo = 2.4892e-10
++ cgbo = 1.0e-13
++ cgdl = 0.0
++ cgsl = 0.0
++ clc = 1.0e-7
++ cle = 0.6
++ cf = 1.4067e-12
++ ckappas = 0.6
++ vfbcv = -1.0
++ acde = 0.4
++ moin = 6.9
++ noff = 3.4037
++ voffcv = -0.17287
+* High-Speed/RF Model Parameters
++ xrcrg1 = 12.0
++ xrcrg2 = 1.0
++ rbpb = 50.0
++ rbpd = 50.0
++ rbps = 50.0
++ rbdb = 50.0
++ rbsb = 50.0
++ gbmin = 1.0e-12
+* Flicker AND Thermal Noise Model Parameters
++ ef = 0.84
++ noia = 2.5e+42
++ noib = 0.0
++ noic = 0.0
++ em = 41000000.0
++ ntnoi = 1.0
++ lintnoi = -1.0e-7
++ af = 1.0
++ kf = 0.0
++ tnoia = 15000000.0
++ tnoib = 9900000.0
++ rnoia = 0.94
++ rnoib = 0.26
+* Layout-Dependent Parasitics Model Parameters
++ xl = 0.0
++ xw = 0.0
++ dmcg = 0.0
++ dmdg = 0.0
++ dmcgt = 0.0
++ xgw = 0.0
++ xgl = 0.0
++ ngcon = 1.0
+* Asymmetric Source/Drain Junction Diode Model Parameters
++ jss = 0.00275
++ jsws = 6.0e-10
++ ijthsfwd = 0.1
++ ijthsrev = 0.1
++ bvs = 11.7
++ xjbvs = 1.0
++ pbs = 0.729
++ cjs = 0.00154845795
++ mjs = 0.44
++ pbsws = 0.2
++ cjsws = 4.24559793e-11
++ mjsws = 0.0009
++ pbswgs = 0.95578
++ cjswgs = 2.75331171e-10
++ mjswgs = 0.8
+* Temperature Dependence Parameters
++ tnom = 30.0
++ kt1 = -1.207000734e-01 lkt1 = -1.808612191e-08 wkt1 = -7.255618328e-17 pkt1 = 1.308853026e-23
++ kt2 = -0.028878939
++ at = -6.409846347e+03 lat = 9.043060963e-03 wat = -2.302019857e-11 pat = 4.152621841e-18
++ ute = -9.857496776e-01 lute = -5.290751180e-08 wute = -1.973030224e-07 pute = 3.559168951e-14
++ ua1 = -2.3847336e-11
++ ub1 = 7.0775317e-19
++ uc1 = 1.4718625e-10
++ kt1l = 0.0
++ prt = 0.0
++ tvoff = 0.0
++ njs = 1.2928
++ tpb = 0.0012287
++ tcj = 0.000792
++ tpbsw = 0.0
++ tcjsw = 1.0e-5
++ tpbswg = 0.0
++ tcjswg = 0.0
++ xtis = 2.0
++ tvfbsdoff = 0.0
+* DW AND DL Parameters
++ ll = 0.0
++ wl = 0.0
++ lln = 1.0
++ wln = 1.0
++ lw = 0.0
++ ww = 0.0
++ lwn = 1.0
++ wwn = 1.0
++ lwl = 0.0
++ wwl = 0.0
++ llc = 0.0
++ wlc = 0.0
++ lwc = 0.0
++ wwc = 0.0
++ lwlc = 0.0
++ wwlc = 0.0
+* Stress Parameters
++ saref = 1.04e-6
++ sbref = 1.04e-6
++ kvth0 = 9.8e-9
++ lkvth0 = 0.0
++ wkvth0 = 2.0e-7
++ pkvth0 = 0.0
++ llodvth = 0.0
++ wlodvth = 1.0
++ wlod = 0.0
++ stk2 = 0.0
++ lodk2 = 1.0
++ lodeta0 = 1.0
++ ku0 = -2.7e-8
++ lku0 = 0.0
++ wku0 = 0.0
++ pku0 = 0.0
++ tku0 = 0.0
++ llodku0 = 0.0
++ wlodku0 = 1.0
++ kvsat = 0.2
++ steta0 = 0.0
+.ends sky130_fd_pr__special_nfet_01v8
+* Well Proximity Effect Parameters

--- a/cells/special_nfet_01v8/sky130_fd_pr__special_nfet_01v8__subvt_mismatch.corner.spice
+++ b/cells/special_nfet_01v8/sky130_fd_pr__special_nfet_01v8__subvt_mismatch.corner.spice
@@ -1,0 +1,22 @@
+* Copyright 2020 The SkyWater PDK Authors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+
+* SKY130 Spice File.
+.param sky130_fd_pr__special_nfet_01v8__toxe_slope=3.443e-03
+.param sky130_fd_pr__special_nfet_01v8__lint_slope=0.0
+.param sky130_fd_pr__special_nfet_01v8__nfactor_slope=0.0
+.param sky130_fd_pr__special_nfet_01v8__voff_slope=0.007
+.param sky130_fd_pr__special_nfet_01v8__vth0_slope=3.356e-03
+.param sky130_fd_pr__special_nfet_01v8__vth0_slope1=7.356e-03
+.param sky130_fd_pr__special_nfet_01v8__wint_slope=0

--- a/cells/special_nfet_01v8/sky130_fd_pr__special_nfet_01v8__tt.corner.spice
+++ b/cells/special_nfet_01v8/sky130_fd_pr__special_nfet_01v8__tt.corner.spice
@@ -1,0 +1,72 @@
+* Copyright 2020 The SkyWater PDK Authors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+
+* SKY130 Spice File.
+* Number of bins: 2
+.param
++ sky130_fd_pr__special_nfet_01v8__toxe_mult = 1.0
++ sky130_fd_pr__special_nfet_01v8__rshn_mult = 1.0
++ sky130_fd_pr__special_nfet_01v8__overlap_mult = 0.9642
++ sky130_fd_pr__special_nfet_01v8__lint_diff = 0.0
++ sky130_fd_pr__special_nfet_01v8__wint_diff = 0.0
++ sky130_fd_pr__special_nfet_01v8__dlc_diff = -.61492e-9
++ sky130_fd_pr__special_nfet_01v8__dwc_diff = 0.0
+*
+* sky130_fd_pr__special_nfet_01v8, Bin 000, W = 0.36, L = 0.15
+* -----------------------------------
++ sky130_fd_pr__special_nfet_01v8__ub_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__eta0_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__tvoff_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__rdsw_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__a0_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__vsat_diff_0 = -2546.2
++ sky130_fd_pr__special_nfet_01v8__kt1_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__vth0_diff_0 = 0.042004
++ sky130_fd_pr__special_nfet_01v8__pdits_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__b0_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__b1_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__voff_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__pditsd_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__pclm_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__u0_diff_0 = -0.0031323
++ sky130_fd_pr__special_nfet_01v8__nfactor_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__keta_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__ags_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__k2_diff_0 = 0.011633
++ sky130_fd_pr__special_nfet_01v8__ua_diff_0 = 0.0
+*
+* sky130_fd_pr__special_nfet_01v8, Bin 001, W = 0.39, L = 0.15
+* -----------------------------------
++ sky130_fd_pr__special_nfet_01v8__ua_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__ub_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__eta0_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__tvoff_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__a0_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__rdsw_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__vsat_diff_1 = -1950.4
++ sky130_fd_pr__special_nfet_01v8__kt1_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__vth0_diff_1 = 0.032109
++ sky130_fd_pr__special_nfet_01v8__pdits_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__b0_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__b1_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__voff_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__pditsd_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__pclm_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__u0_diff_1 = -0.0029036
++ sky130_fd_pr__special_nfet_01v8__nfactor_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__keta_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__ags_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__k2_diff_1 = 0.0090649
+*
+.include "sky130_fd_pr__special_nfet_01v8__tt.pm3.spice"

--- a/cells/special_nfet_01v8/sky130_fd_pr__special_nfet_01v8__tt.pm3.spice
+++ b/cells/special_nfet_01v8/sky130_fd_pr__special_nfet_01v8__tt.pm3.spice
@@ -1,0 +1,574 @@
+* Copyright 2020 The SkyWater PDK Authors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+
+* SKY130 Spice File.
+.param sky130_fd_pr__special_nfet_01v8__toxe_slope_spectre = 0.0
+.param sky130_fd_pr__special_nfet_01v8__vth0_slope_spectre = 0.0
+.param sky130_fd_pr__special_nfet_01v8__voff_slope_spectre = 0.0
+* statistics {
+*   process {
+*   }
+*   mismatch {
+*     vary sky130_fd_pr__special_nfet_01v8__toxe_slope_spectre dist=gauss std = 1.0
+*     vary sky130_fd_pr__special_nfet_01v8__vth0_slope_spectre dist=gauss std = 1.0
+*     vary sky130_fd_pr__special_nfet_01v8__voff_slope_spectre dist=gauss std = 1.0
+*   }
+* }
+.subckt  sky130_fd_pr__special_nfet_01v8 d g s b
++
+.param  l = 1 w = 1 nf = 1.0 ad = 0 as = 0 pd = 0 ps = 0 nrd = 0 nrs = 0 sa = 0 sb = 0 sd = 0 mult = 1
+msky130_fd_pr__special_nfet_01v8 d g s b sky130_fd_pr__special_nfet_01v8__model l = {l} w = {w} nf = {nf} ad = {ad} as = {as} pd = {pd} ps = {ps} nrd = {nrd} nrs = {nrs} sa = {sa} sb = {sb} sd = {sd}
+.model sky130_fd_pr__special_nfet_01v8__model.0 nmos
+* Model Flag Parameters
++ lmin = 1.5e-07 lmax = 1.8e-07 wmin = 3.9e-07 wmax = 4.2e-7
++ level = 54.0
++ version = 4.5
++ binunit = 2.0
++ mobmod = 0.0
++ capmod = 2.0
++ igcmod = 0.0
++ igbmod = 0.0
++ geomod = 0.0
++ diomod = 1.0
++ rdsmod = 0.0
++ rbodymod = 1.0
++ rgatemod = 0.0
++ permod = 1.0
++ acnqsmod = 0.0
++ trnqsmod = 0.0
++ fnoimod = 1.0
++ tnoimod = 1.0
++ tempmod = 0.0
+* Process Parameters
+*(mismatch parameter sky130_fd_pr__special_nfet_01v8__toxe_slope_spectre)
++ toxe = {4.148e-09+MC_MM_SWITCH*AGAUSS(0,1.0,1)*(4.148e-9*1.0*(sky130_fd_pr__special_nfet_01v8__toxe_slope/sqrt(l*w*mult)))}
++ toxm = 4.148e-9
++ dtox = 0.0
++ epsrox = 3.9
++ xj = 1.5e-7
++ ngate = 1.0e+23
++ ndep = 1.7e+17
++ nsd = 1.0e+20
++ rsh = 1.0
++ rshg = 0.1
+* Basic Model Parameters
++ wint = 2.1859e-8
++ lint = 1.1932e-8
+*(mismatch parameter sky130_fd_pr__special_nfet_01v8__vth0_slope_spectre)
++ vth0 = {-1.552765479e+00+MC_MM_SWITCH*AGAUSS(0,1.0,1)*(sky130_fd_pr__special_nfet_01v8__vth0_slope/sqrt(l*w*mult))} lvth0 = 3.118764262e-07 wvth0 = 8.136238717e-07 pvth0 = -1.270359768e-13
++ k1 = 0.90707349
++ k2 = -6.861111273e-01 lk2 = 8.473231032e-08 wk2 = 1.957465773e-07 pk2 = -3.056308759e-14
++ k3 = 2.0
++ k3b = 0.54
++ w0 = 0.0
++ dvt0 = 0.0
++ dvt1 = 0.53
++ dvt2 = -0.032
++ dvt0w = -3.58
++ dvt1w = 1670600.0
++ dvt2w = 0.068
++ dsub = 3.327233918e+00 ldsub = -4.221142877e-07 wdsub = -1.017279861e-06 pdsub = 1.588340084e-13
++ minv = 0.0
++ voffl = 5.8197729e-9
++ lpe0 = 1.0325e-7
++ lpeb = -7.082e-8
++ vbm = -3.0
++ dvtp0 = 0.0
++ dvtp1 = 0.0
++ phin = 0.0
++ cdsc = 0.0
++ cdscb = 0.0
++ cdscd = 0.002052
++ cit = 0.0
+*(mismatch parameter sky130_fd_pr__special_nfet_01v8__voff_slope_spectre)
++ voff = {-0.20753+MC_MM_SWITCH*AGAUSS(0,1.0,1)*(sky130_fd_pr__special_nfet_01v8__voff_slope/sqrt(l*w*mult))}
++ nfactor = -9.376860080e+00 lnfactor = 1.630003644e-06 wnfactor = 1.905910194e-06 pnfactor = -2.975811940e-13
++ eta0 = 0.0
++ etab = -0.043998
++ u0 = 2.328525708e-01 lu0 = -3.255595964e-08 wu0 = -8.966650519e-08 pu0 = 1.400016945e-14
++ ua = -1.393966080e-09 lua = 3.574422705e-17 wua = 1.398486939e-16 pua = -2.183541567e-23
++ ub = 6.496925019e-18 lub = -7.119778210e-25 wub = -2.980183497e-24 pub = 4.653139304e-31
++ uc = -1.261952878e-10 luc = 3.398366988e-17 wuc = 1.186133762e-16 puc = -1.851981810e-23
++ ud = 0.0
++ up = 0.0
++ lp = 1.0
++ eu = 1.67
++ vtl = 0.0
++ xn = 3.0
++ vsat = 3.844848871e+05 lvsat = -3.133632143e-02 wvsat = -9.060217712e-02 pvsat = 1.414626153e-8
++ a0 = 1.5
++ ags = 1.25
++ a1 = 0.0
++ a2 = 0.42385546
++ b0 = 0.0
++ b1 = 0.0
++ keta = -1.038255850e+00 lketa = 1.514331602e-07 wketa = 4.029564649e-07 pketa = -6.291601060e-14
++ dwg = 0.0
++ dwb = 0.0
++ pclm = 1.737606982e-02 lpclm = 2.557100636e-08 wpclm = 1.207637141e-07 ppclm = -1.885556327e-14
++ pdiblc1 = 0.35697215
++ pdiblc2 = 0.0084061121
++ pdiblcb = -0.10329577
++ drout = 0.50332666
++ pscbe1 = 791419880.0
++ pscbe2 = 1.0e-12
++ pvag = 0.0
++ delta = 0.01
++ fprout = 0.0
++ pdits = 0.0
++ pditsl = 0.0
++ pditsd = 0.0
++ lambda = 0.0
++ lc = 5.0e-9
+* Parameters FOR Asymmetric AND Bias-Dependent RDS Model
++ rdsw = 65.968
++ rsw = 0.0
++ rdw = 0.0
++ rdswmin = 0.0
++ rdwmin = 0.0
++ rswmin = 0.0
++ prwb = 0.0
++ prwg = 0.021507
++ wr = 1.0
+* Impact Ionization Current Model Parameters
++ alpha0 = 1.424179121e-07 lalpha0 = -1.417994553e-14 walpha0 = 2.955654554e-21 palpha0 = -4.614840902e-28
++ alpha1 = 0.85
++ beta0 = 1.671249328e+01 lbeta0 = -3.610634506e-07 wbeta0 = 2.044754410e-14 pbeta0 = -3.192596409e-21
+* Gidl Induced Drain Leakage Model Parameters
++ agidl = 0.0
++ bgidl = 2300000000.0
++ cgidl = 0.5
++ egidl = 0.8
+* Gate Dielectric Tunneling Current Model Parameters
++ toxref = 4.148e-9
++ dlcig = 0.0
++ aigbacc = 1.0
++ bigbacc = 0.0
++ cigbacc = 0.0
++ nigbacc = 0.0
++ aigbinv = 0.35
++ bigbinv = 0.03
++ cigbinv = 0.006
++ eigbinv = 1.1
++ nigbinv = 0.0
++ aigc = 0.43
++ bigc = 0.054
++ cigc = 0.075
++ aigsd = 0.43
++ bigsd = 0.054
++ cigsd = 0.075
++ nigc = 0.0
++ poxedge = 1.0
++ pigcd = 1.0
++ ntox = 1.0
++ vfbsdoff = 0.0
+* Charge AND Capacitance Model Parameters
++ dlc = 9.87908e-9
++ dwc = 0.0
++ xpart = 0.0
++ cgso = 2.449068e-10
++ cgdo = 2.449068e-10
++ cgbo = 1.0e-13
++ cgdl = 0.0
++ cgsl = 0.0
++ clc = 1.0e-7
++ cle = 0.6
++ cf = 1.4067e-12
++ ckappas = 0.6
++ vfbcv = -1.0
++ acde = 0.4
++ moin = 6.9
++ noff = 3.4037
++ voffcv = -0.17287
+* High-Speed/RF Model Parameters
++ xrcrg1 = 12.0
++ xrcrg2 = 1.0
++ rbpb = 50.0
++ rbpd = 50.0
++ rbps = 50.0
++ rbdb = 50.0
++ rbsb = 50.0
++ gbmin = 1.0e-12
+* Flicker AND Thermal Noise Model Parameters
++ ef = 0.84
++ noia = 2.5e+42
++ noib = 0.0
++ noic = 0.0
++ em = 41000000.0
++ ntnoi = 1.0
++ lintnoi = -1.0e-7
++ af = 1.0
++ kf = 0.0
++ tnoia = 15000000.0
++ tnoib = 9900000.0
++ rnoia = 0.94
++ rnoib = 0.26
+* Layout-Dependent Parasitics Model Parameters
++ xl = 0.0
++ xw = 0.0
++ dmcg = 0.0
++ dmdg = 0.0
++ dmcgt = 0.0
++ xgw = 0.0
++ xgl = 0.0
++ ngcon = 1.0
+* Asymmetric Source/Drain Junction Diode Model Parameters
++ jss = 0.00275
++ jsws = 6.0e-10
++ ijthsfwd = 0.1
++ ijthsrev = 0.1
++ bvs = 11.7
++ xjbvs = 1.0
++ pbs = 0.729
++ cjs = 0.001339749237
++ mjs = 0.44
++ pbsws = 0.2
++ cjsws = 3.67354204e-11
++ mjsws = 0.0009
++ pbswgs = 0.95578
++ cjswgs = 2.38232788e-10
++ mjswgs = 0.8
+* Temperature Dependence Parameters
++ tnom = 30.0
++ kt1 = -1.368700706e-01 lkt1 = -1.312958075e-08 wkt1 = -1.018287676e-15 pkt1 = 1.589913756e-22
++ kt2 = -0.028878939
++ at = 1.675154536e+03 lat = 6.564790030e-03 wat = -3.270385787e-10 pat = 5.106249591e-17
++ ute = -9.418347041e-01 lute = -5.265038572e-08 wute = -2.218109000e-07 pute = 3.463266668e-14
++ ua1 = -2.3847336e-11
++ ub1 = 7.0775317e-19
++ uc1 = 1.4718625e-10
++ kt1l = 0.0
++ prt = 0.0
++ tvoff = 0.0
++ njs = 1.2928
++ tpb = 0.0012287
++ tcj = 0.000792
++ tpbsw = 0.0
++ tcjsw = 1.0e-5
++ tpbswg = 0.0
++ tcjswg = 0.0
++ xtis = 2.0
++ tvfbsdoff = 0.0
+* DW AND DL Parameters
++ ll = 0.0
++ wl = 0.0
++ lln = 1.0
++ wln = 1.0
++ lw = 0.0
++ ww = 0.0
++ lwn = 1.0
++ wwn = 1.0
++ lwl = 0.0
++ wwl = 0.0
++ llc = 0.0
++ wlc = 0.0
++ lwc = 0.0
++ wwc = 0.0
++ lwlc = 0.0
++ wwlc = 0.0
+* Stress Parameters
++ saref = 1.04e-6
++ sbref = 1.04e-6
++ kvth0 = 9.8e-9
++ lkvth0 = 0.0
++ wkvth0 = 2.0e-7
++ pkvth0 = 0.0
++ llodvth = 0.0
++ wlodvth = 1.0
++ wlod = 0.0
++ stk2 = 0.0
++ lodk2 = 1.0
++ lodeta0 = 1.0
++ ku0 = -2.7e-8
++ lku0 = 0.0
++ wku0 = 0.0
++ pku0 = 0.0
++ tku0 = 0.0
++ llodku0 = 0.0
++ wlodku0 = 1.0
++ kvsat = 0.2
++ steta0 = 0.0
+* Well Proximity Effect Parameters
+.model sky130_fd_pr__special_nfet_01v8__model.1 nmos
+* Model Flag Parameters
++ lmin = 1.5e-07 lmax = 1.8e-07 wmin = 3.6e-07 wmax = 3.9e-7
++ level = 54.0
++ version = 4.5
++ binunit = 2.0
++ mobmod = 0.0
++ capmod = 2.0
++ igcmod = 0.0
++ igbmod = 0.0
++ geomod = 0.0
++ diomod = 1.0
++ rdsmod = 0.0
++ rbodymod = 1.0
++ rgatemod = 0.0
++ permod = 1.0
++ acnqsmod = 0.0
++ trnqsmod = 0.0
++ fnoimod = 1.0
++ tnoimod = 1.0
++ tempmod = 0.0
+* Process Parameters
+*(mismatch parameter sky130_fd_pr__special_nfet_01v8__toxe_slope_spectre)
++ toxe = {4.148e-09+MC_MM_SWITCH*AGAUSS(0,1.0,1)*(4.148e-9*1.0*(sky130_fd_pr__special_nfet_01v8__toxe_slope/sqrt(l*w*mult)))}
++ toxm = 4.148e-9
++ dtox = 0.0
++ epsrox = 3.9
++ xj = 1.5e-7
++ ngate = 1.0e+23
++ ndep = 1.7e+17
++ nsd = 1.0e+20
++ rsh = 1.0
++ rshg = 0.1
+* Basic Model Parameters
++ wint = 2.1859e-8
++ lint = 1.1932e-8
+*(mismatch parameter sky130_fd_pr__special_nfet_01v8__vth0_slope_spectre)
++ vth0 = {-2.993931675e-01+MC_MM_SWITCH*AGAUSS(0,1.0,1)*(sky130_fd_pr__special_nfet_01v8__vth0_slope/sqrt(l*w*mult))} lvth0 = 1.161798869e-07 wvth0 = 3.796036009e-07 pvth0 = -5.926978783e-14
++ k1 = 0.90707349
++ k2 = -3.222046665e-01 lk2 = 2.791341115e-08 wk2 = 6.973232022e-08 pk2 = -1.088772555e-14
++ k3 = 2.0
++ k3b = 0.54
++ w0 = 0.0
++ dvt0 = 0.0
++ dvt1 = 0.53
++ dvt2 = -0.032
++ dvt0w = -3.58
++ dvt1w = 1670600.0
++ dvt2w = 0.068
++ dsub = 3.327233912e+00 ldsub = -4.221142868e-07 wdsub = -1.017279859e-06 pdsub = 1.588340081e-13
++ minv = 0.0
++ voffl = 5.8197729e-9
++ lpe0 = 1.0325e-7
++ lpeb = -7.082e-8
++ vbm = -3.0
++ dvtp0 = 0.0
++ dvtp1 = 0.0
++ phin = 0.0
++ cdsc = 0.0
++ cdscb = 0.0
++ cdscd = 0.002052
++ cit = 0.0
+*(mismatch parameter sky130_fd_pr__special_nfet_01v8__voff_slope_spectre)
++ voff = {-0.20753+MC_MM_SWITCH*AGAUSS(0,1.0,1)*(sky130_fd_pr__special_nfet_01v8__voff_slope/sqrt(l*w*mult))}
++ nfactor = -9.376859947e+00 lnfactor = 1.630003623e-06 wnfactor = 1.905910148e-06 pnfactor = -2.975811868e-13
++ eta0 = 0.0
++ etab = -0.043998
++ u0 = 8.959275208e-02 lu0 = -1.018794459e-08 wu0 = -4.005820865e-08 pu0 = 6.254528466e-15
++ ua = -1.393966070e-09 lua = 3.574422544e-17 wua = 1.398486904e-16 pua = -2.183541512e-23
++ ub = 6.496924862e-18 lub = -7.119777965e-25 wub = -2.980183442e-24 pub = 4.653139219e-31
++ uc = -1.261952913e-10 luc = 3.398367043e-17 wuc = 1.186133774e-16 puc = -1.851981829e-23
++ ud = 0.0
++ up = 0.0
++ lp = 1.0
++ eu = 1.67
++ vtl = 0.0
++ xn = 3.0
++ vsat = 3.102888726e+05 lvsat = -1.975165252e-02 wvsat = -6.490943285e-02 pvsat = 1.013469921e-8
++ a0 = 1.5
++ ags = 1.25
++ a1 = 0.0
++ a2 = 0.42385546
++ b0 = 0.0
++ b1 = 0.0
++ keta = -1.038255847e+00 lketa = 1.514331597e-07 wketa = 4.029564638e-07 pketa = -6.291601043e-14
++ dwg = 0.0
++ dwb = 0.0
++ pclm = 1.737607849e-02 lpclm = 2.557100501e-08 wpclm = 1.207637111e-07 ppclm = -1.885556280e-14
++ pdiblc1 = 0.35697215
++ pdiblc2 = 0.0084061121
++ pdiblcb = -0.10329577
++ drout = 0.50332666
++ pscbe1 = 791419880.0
++ pscbe2 = 1.0e-12
++ pvag = 0.0
++ delta = 0.01
++ fprout = 0.0
++ pdits = 0.0
++ pditsl = 0.0
++ pditsd = 0.0
++ lambda = 0.0
++ lc = 5.0e-9
+* Parameters FOR Asymmetric AND Bias-Dependent RDS Model
++ rdsw = 65.968
++ rsw = 0.0
++ rdw = 0.0
++ rdswmin = 0.0
++ rdwmin = 0.0
++ rswmin = 0.0
++ prwb = 0.0
++ prwg = 0.021507
++ wr = 1.0
+* Impact Ionization Current Model Parameters
++ alpha0 = 1.424179200e-07 lalpha0 = -1.417994676e-14 walpha0 = 2.191742220e-22 palpha0 = -3.422097810e-29
++ alpha1 = 0.85
++ beta0 = 1.671249334e+01 lbeta0 = -3.610634598e-07 wbeta0 = 3.836930773e-17 pbeta0 = -5.989875262e-24
+* Gidl Induced Drain Leakage Model Parameters
++ agidl = 0.0
++ bgidl = 2300000000.0
++ cgidl = 0.5
++ egidl = 0.8
+* Gate Dielectric Tunneling Current Model Parameters
++ toxref = 4.148e-9
++ dlcig = 0.0
++ aigbacc = 1.0
++ bigbacc = 0.0
++ cigbacc = 0.0
++ nigbacc = 0.0
++ aigbinv = 0.35
++ bigbinv = 0.03
++ cigbinv = 0.006
++ eigbinv = 1.1
++ nigbinv = 0.0
++ aigc = 0.43
++ bigc = 0.054
++ cigc = 0.075
++ aigsd = 0.43
++ bigsd = 0.054
++ cigsd = 0.075
++ nigc = 0.0
++ poxedge = 1.0
++ pigcd = 1.0
++ ntox = 1.0
++ vfbsdoff = 0.0
+* Charge AND Capacitance Model Parameters
++ dlc = 9.87908e-9
++ dwc = 0.0
++ xpart = 0.0
++ cgso = 2.449068e-10
++ cgdo = 2.449068e-10
++ cgbo = 1.0e-13
++ cgdl = 0.0
++ cgsl = 0.0
++ clc = 1.0e-7
++ cle = 0.6
++ cf = 1.4067e-12
++ ckappas = 0.6
++ vfbcv = -1.0
++ acde = 0.4
++ moin = 6.9
++ noff = 3.4037
++ voffcv = -0.17287
+* High-Speed/RF Model Parameters
++ xrcrg1 = 12.0
++ xrcrg2 = 1.0
++ rbpb = 50.0
++ rbpd = 50.0
++ rbps = 50.0
++ rbdb = 50.0
++ rbsb = 50.0
++ gbmin = 1.0e-12
+* Flicker AND Thermal Noise Model Parameters
++ ef = 0.84
++ noia = 2.5e+42
++ noib = 0.0
++ noic = 0.0
++ em = 41000000.0
++ ntnoi = 1.0
++ lintnoi = -1.0e-7
++ af = 1.0
++ kf = 0.0
++ tnoia = 15000000.0
++ tnoib = 9900000.0
++ rnoia = 0.94
++ rnoib = 0.26
+* Layout-Dependent Parasitics Model Parameters
++ xl = 0.0
++ xw = 0.0
++ dmcg = 0.0
++ dmdg = 0.0
++ dmcgt = 0.0
++ xgw = 0.0
++ xgl = 0.0
++ ngcon = 1.0
+* Asymmetric Source/Drain Junction Diode Model Parameters
++ jss = 0.00275
++ jsws = 6.0e-10
++ ijthsfwd = 0.1
++ ijthsrev = 0.1
++ bvs = 11.7
++ xjbvs = 1.0
++ pbs = 0.729
++ cjs = 0.001339749237
++ mjs = 0.44
++ pbsws = 0.2
++ cjsws = 3.67354204e-11
++ mjsws = 0.0009
++ pbswgs = 0.95578
++ cjswgs = 2.38232788e-10
++ mjswgs = 0.8
+* Temperature Dependence Parameters
++ tnom = 30.0
++ kt1 = -1.368700733e-01 lkt1 = -1.312958033e-08 wkt1 = -8.156852971e-17 pkt1 = 1.273581240e-23
++ kt2 = -0.028878939
++ at = 1.675153666e+03 lat = 6.564790165e-03 wat = -2.587959170e-11 pat = 4.040746717e-18
++ ute = -9.418347116e-01 lute = -5.265038454e-08 wute = -2.218108973e-07 pute = 3.463266627e-14
++ ua1 = -2.3847336e-11
++ ub1 = 7.0775317e-19
++ uc1 = 1.4718625e-10
++ kt1l = 0.0
++ prt = 0.0
++ tvoff = 0.0
++ njs = 1.2928
++ tpb = 0.0012287
++ tcj = 0.000792
++ tpbsw = 0.0
++ tcjsw = 1.0e-5
++ tpbswg = 0.0
++ tcjswg = 0.0
++ xtis = 2.0
++ tvfbsdoff = 0.0
+* DW AND DL Parameters
++ ll = 0.0
++ wl = 0.0
++ lln = 1.0
++ wln = 1.0
++ lw = 0.0
++ ww = 0.0
++ lwn = 1.0
++ wwn = 1.0
++ lwl = 0.0
++ wwl = 0.0
++ llc = 0.0
++ wlc = 0.0
++ lwc = 0.0
++ wwc = 0.0
++ lwlc = 0.0
++ wwlc = 0.0
+* Stress Parameters
++ saref = 1.04e-6
++ sbref = 1.04e-6
++ kvth0 = 9.8e-9
++ lkvth0 = 0.0
++ wkvth0 = 2.0e-7
++ pkvth0 = 0.0
++ llodvth = 0.0
++ wlodvth = 1.0
++ wlod = 0.0
++ stk2 = 0.0
++ lodk2 = 1.0
++ lodeta0 = 1.0
++ ku0 = -2.7e-8
++ lku0 = 0.0
++ wku0 = 0.0
++ pku0 = 0.0
++ tku0 = 0.0
++ llodku0 = 0.0
++ wlodku0 = 1.0
++ kvsat = 0.2
++ steta0 = 0.0
+.ends sky130_fd_pr__special_nfet_01v8
+* Well Proximity Effect Parameters

--- a/cells/special_nfet_01v8/sky130_fd_pr__special_nfet_01v8__tt_correln.corner.spice
+++ b/cells/special_nfet_01v8/sky130_fd_pr__special_nfet_01v8__tt_correln.corner.spice
@@ -1,0 +1,73 @@
+* Copyright 2020 The SkyWater PDK Authors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+
+* SKY130 Spice File.
+.param sky130_fd_pr__special_nfet_01v8__vth0_correldiff = -0.0168
+* Number of bins: 2
+.param
++ sky130_fd_pr__special_nfet_01v8__toxe_mult = 1.0
++ sky130_fd_pr__special_nfet_01v8__rshn_mult = 1.0
++ sky130_fd_pr__special_nfet_01v8__overlap_mult = 0.9642
++ sky130_fd_pr__special_nfet_01v8__lint_diff = 0.0
++ sky130_fd_pr__special_nfet_01v8__wint_diff = 0.0
++ sky130_fd_pr__special_nfet_01v8__dlc_diff = -.61492e-9
++ sky130_fd_pr__special_nfet_01v8__dwc_diff = 0.0
+*
+* sky130_fd_pr__special_nfet_01v8, Bin 000, W = 0.36, L = 0.15
+* -----------------------------------
++ sky130_fd_pr__special_nfet_01v8__ub_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__eta0_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__tvoff_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__rdsw_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__a0_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__vsat_diff_0 = -2546.2
++ sky130_fd_pr__special_nfet_01v8__kt1_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__vth0_diff_0 = ' 0.042004 + sky130_fd_pr__special_nfet_01v8__vth0_correldiff'
++ sky130_fd_pr__special_nfet_01v8__pdits_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__b0_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__b1_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__voff_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__pditsd_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__pclm_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__u0_diff_0 = -0.0031323
++ sky130_fd_pr__special_nfet_01v8__nfactor_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__keta_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__ags_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__k2_diff_0 = 0.011633
++ sky130_fd_pr__special_nfet_01v8__ua_diff_0 = 0.0
+*
+* sky130_fd_pr__special_nfet_01v8, Bin 001, W = 0.39, L = 0.15
+* -----------------------------------
++ sky130_fd_pr__special_nfet_01v8__ua_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__ub_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__eta0_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__tvoff_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__a0_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__rdsw_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__vsat_diff_1 = -1950.4
++ sky130_fd_pr__special_nfet_01v8__kt1_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__vth0_diff_1 = ' 0.032109 + sky130_fd_pr__special_nfet_01v8__vth0_correldiff'
++ sky130_fd_pr__special_nfet_01v8__pdits_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__b0_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__b1_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__voff_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__pditsd_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__pclm_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__u0_diff_1 = -0.0029036
++ sky130_fd_pr__special_nfet_01v8__nfactor_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__keta_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__ags_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__k2_diff_1 = 0.0090649
+*
+.include "sky130_fd_pr__special_nfet_01v8.pm3.spice"

--- a/cells/special_nfet_01v8/sky130_fd_pr__special_nfet_01v8__tt_correlp.corner.spice
+++ b/cells/special_nfet_01v8/sky130_fd_pr__special_nfet_01v8__tt_correlp.corner.spice
@@ -1,0 +1,73 @@
+* Copyright 2020 The SkyWater PDK Authors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+
+* SKY130 Spice File.
+.param sky130_fd_pr__special_nfet_01v8__vth0_correldiff = 0.0168
+* Number of bins: 2
+.param
++ sky130_fd_pr__special_nfet_01v8__toxe_mult = 1.0
++ sky130_fd_pr__special_nfet_01v8__rshn_mult = 1.0
++ sky130_fd_pr__special_nfet_01v8__overlap_mult = 0.9642
++ sky130_fd_pr__special_nfet_01v8__lint_diff = 0.0
++ sky130_fd_pr__special_nfet_01v8__wint_diff = 0.0
++ sky130_fd_pr__special_nfet_01v8__dlc_diff = -.61492e-9
++ sky130_fd_pr__special_nfet_01v8__dwc_diff = 0.0
+*
+* sky130_fd_pr__special_nfet_01v8, Bin 000, W = 0.36, L = 0.15
+* -----------------------------------
++ sky130_fd_pr__special_nfet_01v8__ub_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__eta0_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__tvoff_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__rdsw_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__a0_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__vsat_diff_0 = -2546.2
++ sky130_fd_pr__special_nfet_01v8__kt1_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__vth0_diff_0 = ' 0.042004 + sky130_fd_pr__special_nfet_01v8__vth0_correldiff'
++ sky130_fd_pr__special_nfet_01v8__pdits_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__b0_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__b1_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__voff_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__pditsd_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__pclm_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__u0_diff_0 = -0.0031323
++ sky130_fd_pr__special_nfet_01v8__nfactor_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__keta_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__ags_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__k2_diff_0 = 0.011633
++ sky130_fd_pr__special_nfet_01v8__ua_diff_0 = 0.0
+*
+* sky130_fd_pr__special_nfet_01v8, Bin 001, W = 0.39, L = 0.15
+* -----------------------------------
++ sky130_fd_pr__special_nfet_01v8__ua_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__ub_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__eta0_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__tvoff_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__a0_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__rdsw_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__vsat_diff_1 = -1950.4
++ sky130_fd_pr__special_nfet_01v8__kt1_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__vth0_diff_1 = ' 0.032109 + sky130_fd_pr__special_nfet_01v8__vth0_correldiff'
++ sky130_fd_pr__special_nfet_01v8__pdits_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__b0_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__b1_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__voff_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__pditsd_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__pclm_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__u0_diff_1 = -0.0029036
++ sky130_fd_pr__special_nfet_01v8__nfactor_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__keta_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__ags_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__k2_diff_1 = 0.0090649
+*
+.include "sky130_fd_pr__special_nfet_01v8.pm3.spice"

--- a/cells/special_nfet_01v8/sky130_fd_pr__special_nfet_01v8__tt_leak.corner.spice
+++ b/cells/special_nfet_01v8/sky130_fd_pr__special_nfet_01v8__tt_leak.corner.spice
@@ -1,0 +1,72 @@
+* Copyright 2020 The SkyWater PDK Authors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+
+* SKY130 Spice File.
+* Number of bins: 2
+.param
++ sky130_fd_pr__special_nfet_01v8__toxe_mult = 1.0
++ sky130_fd_pr__special_nfet_01v8__rshn_mult = 1.0
++ sky130_fd_pr__special_nfet_01v8__overlap_mult = 0.9642
++ sky130_fd_pr__special_nfet_01v8__lint_diff = 0.0
++ sky130_fd_pr__special_nfet_01v8__wint_diff = 0.0
++ sky130_fd_pr__special_nfet_01v8__dlc_diff = -.61491e-9
++ sky130_fd_pr__special_nfet_01v8__dwc_diff = 0.0
+*
+* sky130_fd_pr__special_nfet_01v8, Bin 000, W = 0.36, L = 0.15
+* -----------------------------------
++ sky130_fd_pr__special_nfet_01v8__ub_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__eta0_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__tvoff_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__rdsw_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__a0_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__vsat_diff_0 = 2522.7
++ sky130_fd_pr__special_nfet_01v8__kt1_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__vth0_diff_0 = 0.042691
++ sky130_fd_pr__special_nfet_01v8__pdits_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__b0_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__b1_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__voff_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__pditsd_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__pclm_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__u0_diff_0 = 0.0031326
++ sky130_fd_pr__special_nfet_01v8__nfactor_diff_0 = 0.93967
++ sky130_fd_pr__special_nfet_01v8__keta_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__ags_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__k2_diff_0 = -0.011632
++ sky130_fd_pr__special_nfet_01v8__ua_diff_0 = 0.0
+*
+* sky130_fd_pr__special_nfet_01v8, Bin 001, W = 0.39, L = 0.15
+* -----------------------------------
++ sky130_fd_pr__special_nfet_01v8__ua_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__ub_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__eta0_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__tvoff_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__a0_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__rdsw_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__vsat_diff_1 = 1928.2
++ sky130_fd_pr__special_nfet_01v8__kt1_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__vth0_diff_1 = 0.032658
++ sky130_fd_pr__special_nfet_01v8__pdits_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__b0_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__b1_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__voff_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__pditsd_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__pclm_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__u0_diff_1 = 0.0029052
++ sky130_fd_pr__special_nfet_01v8__nfactor_diff_1 = 0.83163
++ sky130_fd_pr__special_nfet_01v8__keta_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__ags_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__k2_diff_1 = -0.009063
+*
+.include "sky130_fd_pr__special_nfet_01v8.pm3.spice"

--- a/cells/special_nfet_01v8/sky130_fd_pr__special_nfet_01v8__tt_leak.pm3.spice
+++ b/cells/special_nfet_01v8/sky130_fd_pr__special_nfet_01v8__tt_leak.pm3.spice
@@ -1,0 +1,574 @@
+* Copyright 2020 The SkyWater PDK Authors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+
+* SKY130 Spice File.
+.param sky130_fd_pr__special_nfet_01v8__toxe_slope_spectre = 0.0
+.param sky130_fd_pr__special_nfet_01v8__vth0_slope_spectre = 0.0
+.param sky130_fd_pr__special_nfet_01v8__voff_slope_spectre = 0.0
+* statistics {
+*   process {
+*   }
+*   mismatch {
+*     vary sky130_fd_pr__special_nfet_01v8__toxe_slope_spectre dist=gauss std = 1.0
+*     vary sky130_fd_pr__special_nfet_01v8__vth0_slope_spectre dist=gauss std = 1.0
+*     vary sky130_fd_pr__special_nfet_01v8__voff_slope_spectre dist=gauss std = 1.0
+*   }
+* }
+.subckt  sky130_fd_pr__special_nfet_01v8 d g s b
++ 
+.param  l = 1 w = 1 nf = 1.0 ad = 0 as = 0 pd = 0 ps = 0 nrd = 0 nrs = 0 sa = 0 sb = 0 sd = 0 mult = 1
+msky130_fd_pr__special_nfet_01v8 d g s b sky130_fd_pr__special_nfet_01v8__model l = {l} w = {w} nf = {nf} ad = {ad} as = {as} pd = {pd} ps = {ps} nrd = {nrd} nrs = {nrs} sa = {sa} sb = {sb} sd = {sd}
+.model sky130_fd_pr__special_nfet_01v8__model.0 nmos
+* Model Flag Parameters
++ lmin = 1.5e-07 lmax = 1.8e-07 wmin = 3.9e-07 wmax = 4.2e-7
++ level = 54.0
++ version = 4.5
++ binunit = 2.0
++ mobmod = 0.0
++ capmod = 2.0
++ igcmod = 0.0
++ igbmod = 0.0
++ geomod = 0.0
++ diomod = 1.0
++ rdsmod = 0.0
++ rbodymod = 1.0
++ rgatemod = 0.0
++ permod = 1.0
++ acnqsmod = 0.0
++ trnqsmod = 0.0
++ fnoimod = 1.0
++ tnoimod = 1.0
++ tempmod = 0.0
+* Process Parameters
+*(mismatch parameter sky130_fd_pr__special_nfet_01v8__toxe_slope_spectre)
++ toxe = {4.148e-09+MC_MM_SWITCH*AGAUSS(0,1.0,1)*(4.148e-9*1.0*(sky130_fd_pr__special_nfet_01v8__toxe_slope/sqrt(l*w*mult)))}
++ toxm = 4.148e-9
++ dtox = 0.0
++ epsrox = 3.9
++ xj = 1.5e-7
++ ngate = 1.0e+23
++ ndep = 1.7e+17
++ nsd = 1.0e+20
++ rsh = 1.0
++ rshg = 0.1
+* Basic Model Parameters
++ wint = 2.1859e-8
++ lint = 1.1932e-8
+*(mismatch parameter sky130_fd_pr__special_nfet_01v8__vth0_slope_spectre)
++ vth0 = {-1.845492211e+00+MC_MM_SWITCH*AGAUSS(0,1.0,1)*(sky130_fd_pr__special_nfet_01v8__vth0_slope/sqrt(l*w*mult))} lvth0 = 3.582714160e-07 wvth0 = 9.221528304e-07 pvth0 = -1.439812543e-13
++ k1 = 0.90707349
++ k2 = -1.469863474e+00 lk2 = 2.069750797e-07 wk2 = 4.920481293e-07 pk2 = -7.682642672e-14
++ k3 = 2.0
++ k3b = 0.54
++ w0 = 0.0
++ dvt0 = 0.0
++ dvt1 = 0.53
++ dvt2 = -0.032
++ dvt0w = -3.58
++ dvt1w = 1670600.0
++ dvt2w = 0.068
++ dsub = 3.327233918e+00 ldsub = -4.221142877e-07 wdsub = -1.017279861e-06 pdsub = 1.588340084e-13
++ minv = 0.0
++ voffl = 5.8197729e-9
++ lpe0 = 1.0325e-7
++ lpeb = -7.082e-8
++ vbm = -3.0
++ dvtp0 = 0.0
++ dvtp1 = 0.0
++ phin = 0.0
++ cdsc = 0.0
++ cdscb = 0.0
++ cdscd = 0.002052
++ cit = 0.0
+*(mismatch parameter sky130_fd_pr__special_nfet_01v8__voff_slope_spectre)
++ voff = {3.866578765e+00+MC_MM_SWITCH*AGAUSS(0,1.0,1)*(sky130_fd_pr__special_nfet_01v8__voff_slope/sqrt(l*w*mult))} lvoff = -6.528325277e-07 wvoff = -1.603755963e-06 pvoff = 2.504040410e-13
++ nfactor = 3.541633038e+01 lnfactor = -5.217698260e-06 wnfactor = -1.312926772e-05 pnfactor = 2.049951344e-12
++ eta0 = 0.0
++ etab = -0.043998
++ u0 = 5.002217776e-01 lu0 = -7.428096467e-08 wu0 = -1.904671356e-07 pu0 = 2.973877668e-14
++ ua = -1.393966080e-09 lua = 3.574422705e-17 wua = 1.398486939e-16 pua = -2.183541567e-23
++ ub = 6.496925019e-18 lub = -7.119778210e-25 wub = -2.980183497e-24 pub = 4.653139304e-31
++ uc = -1.261952878e-10 luc = 3.398366988e-17 wuc = 1.186133762e-16 puc = -1.851981810e-23
++ ud = 0.0
++ up = 0.0
++ lp = 1.0
++ eu = 1.67
++ vtl = 0.0
++ xn = 3.0
++ vsat = 4.815522429e+05 lvsat = -4.627562560e-02 wvsat = -1.273640198e-01 pvsat = 1.988610860e-8
++ a0 = 1.5
++ ags = 1.25
++ a1 = 0.0
++ a2 = 0.42385546
++ b0 = 0.0
++ b1 = 0.0
++ keta = -1.038255850e+00 lketa = 1.514331602e-07 wketa = 4.029564649e-07 pketa = -6.291601060e-14
++ dwg = 0.0
++ dwb = 0.0
++ pclm = 1.737606982e-02 lpclm = 2.557100636e-08 wpclm = 1.207637141e-07 ppclm = -1.885556327e-14
++ pdiblc1 = 0.35697215
++ pdiblc2 = 0.0084061121
++ pdiblcb = -0.10329577
++ drout = 0.50332666
++ pscbe1 = 791419880.0
++ pscbe2 = 1.0e-12
++ pvag = 0.0
++ delta = 0.01
++ fprout = 0.0
++ pdits = 0.0
++ pditsl = 0.0
++ pditsd = 0.0
++ lambda = 0.0
++ lc = 5.0e-9
+* Parameters FOR Asymmetric AND Bias-Dependent RDS Model
++ rdsw = 65.968
++ rsw = 0.0
++ rdw = 0.0
++ rdswmin = 0.0
++ rdwmin = 0.0
++ rswmin = 0.0
++ prwb = 0.0
++ prwg = 0.021507
++ wr = 1.0
+* Impact Ionization Current Model Parameters
++ alpha0 = 1.424179121e-07 lalpha0 = -1.417994553e-14 walpha0 = 2.955654554e-21 palpha0 = -4.614840902e-28
++ alpha1 = 0.85
++ beta0 = 1.671249328e+01 lbeta0 = -3.610634506e-07 wbeta0 = 2.044754410e-14 pbeta0 = -3.192596409e-21
+* Gidl Induced Drain Leakage Model Parameters
++ agidl = 0.0
++ bgidl = 2300000000.0
++ cgidl = 0.5
++ egidl = 0.8
+* Gate Dielectric Tunneling Current Model Parameters
++ toxref = 4.148e-9
++ dlcig = 0.0
++ aigbacc = 1.0
++ bigbacc = 0.0
++ cigbacc = 0.0
++ nigbacc = 0.0
++ aigbinv = 0.35
++ bigbinv = 0.03
++ cigbinv = 0.006
++ eigbinv = 1.1
++ nigbinv = 0.0
++ aigc = 0.43
++ bigc = 0.054
++ cigc = 0.075
++ aigsd = 0.43
++ bigsd = 0.054
++ cigsd = 0.075
++ nigc = 0.0
++ poxedge = 1.0
++ pigcd = 1.0
++ ntox = 1.0
++ vfbsdoff = 0.0
+* Charge AND Capacitance Model Parameters
++ dlc = 9.87909e-9
++ dwc = 0.0
++ xpart = 0.0
++ cgso = 2.449068e-10
++ cgdo = 2.449068e-10
++ cgbo = 1.0e-13
++ cgdl = 0.0
++ cgsl = 0.0
++ clc = 1.0e-7
++ cle = 0.6
++ cf = 1.4067e-12
++ ckappas = 0.6
++ vfbcv = -1.0
++ acde = 0.4
++ moin = 6.9
++ noff = 3.4037
++ voffcv = -0.17287
+* High-Speed/RF Model Parameters
++ xrcrg1 = 12.0
++ xrcrg2 = 1.0
++ rbpb = 50.0
++ rbpd = 50.0
++ rbps = 50.0
++ rbdb = 50.0
++ rbsb = 50.0
++ gbmin = 1.0e-12
+* Flicker AND Thermal Noise Model Parameters
++ ef = 0.84
++ noia = 2.5e+42
++ noib = 0.0
++ noic = 0.0
++ em = 41000000.0
++ ntnoi = 1.0
++ lintnoi = -1.0e-7
++ af = 1.0
++ kf = 0.0
++ tnoia = 15000000.0
++ tnoib = 9900000.0
++ rnoia = 0.94
++ rnoib = 0.26
+* Layout-Dependent Parasitics Model Parameters
++ xl = 0.0
++ xw = 0.0
++ dmcg = 0.0
++ dmdg = 0.0
++ dmcgt = 0.0
++ xgw = 0.0
++ xgl = 0.0
++ ngcon = 1.0
+* Asymmetric Source/Drain Junction Diode Model Parameters
++ jss = 0.00275
++ jsws = 6.0e-10
++ ijthsfwd = 0.1
++ ijthsrev = 0.1
++ bvs = 11.7
++ xjbvs = 1.0
++ pbs = 0.729
++ cjs = 0.001339749237
++ mjs = 0.44
++ pbsws = 0.2
++ cjsws = 3.67354204e-11
++ mjsws = 0.0009
++ pbswgs = 0.95578
++ cjswgs = 2.38232788e-10
++ mjswgs = 0.8
+* Temperature Dependence Parameters
++ tnom = 30.0
++ kt1 = -1.368700706e-01 lkt1 = -1.312958075e-08 wkt1 = -1.018287676e-15 pkt1 = 1.589913756e-22
++ kt2 = -0.028878939
++ at = 1.675154536e+03 lat = 6.564790030e-03 wat = -3.270385787e-10 pat = 5.106249591e-17
++ ute = -9.418347041e-01 lute = -5.265038572e-08 wute = -2.218109000e-07 pute = 3.463266668e-14
++ ua1 = -2.3847336e-11
++ ub1 = 7.0775317e-19
++ uc1 = 1.4718625e-10
++ kt1l = 0.0
++ prt = 0.0
++ tvoff = 6.886122803e-02 ltvoff = -1.087043002e-08 wtvoff = -2.521568000e-08 ptvoff = 3.937075413e-15
++ njs = 1.2928
++ tpb = 0.0012287
++ tcj = 0.000792
++ tpbsw = 0.0
++ tcjsw = 1.0e-5
++ tpbswg = 0.0
++ tcjswg = 0.0
++ xtis = 2.0
++ tvfbsdoff = 0.0
+* DW AND DL Parameters
++ ll = 0.0
++ wl = 0.0
++ lln = 1.0
++ wln = 1.0
++ lw = 0.0
++ ww = 0.0
++ lwn = 1.0
++ wwn = 1.0
++ lwl = 0.0
++ wwl = 0.0
++ llc = 0.0
++ wlc = 0.0
++ lwc = 0.0
++ wwc = 0.0
++ lwlc = 0.0
++ wwlc = 0.0
+* Stress Parameters
++ saref = 1.04e-6
++ sbref = 1.04e-6
++ kvth0 = 9.8e-9
++ lkvth0 = 0.0
++ wkvth0 = 2.0e-7
++ pkvth0 = 0.0
++ llodvth = 0.0
++ wlodvth = 1.0
++ wlod = 0.0
++ stk2 = 0.0
++ lodk2 = 1.0
++ lodeta0 = 1.0
++ ku0 = -2.7e-8
++ lku0 = 0.0
++ wku0 = 0.0
++ pku0 = 0.0
++ tku0 = 0.0
++ llodku0 = 0.0
++ wlodku0 = 1.0
++ kvsat = 0.2
++ steta0 = 0.0
+* Well Proximity Effect Parameters
+.model sky130_fd_pr__special_nfet_01v8__model.1 nmos
+* Model Flag Parameters
++ lmin = 1.5e-07 lmax = 1.8e-07 wmin = 3.6e-07 wmax = 3.9e-7
++ level = 54.0
++ version = 4.5
++ binunit = 2.0
++ mobmod = 0.0
++ capmod = 2.0
++ igcmod = 0.0
++ igbmod = 0.0
++ geomod = 0.0
++ diomod = 1.0
++ rdsmod = 0.0
++ rbodymod = 1.0
++ rgatemod = 0.0
++ permod = 1.0
++ acnqsmod = 0.0
++ trnqsmod = 0.0
++ fnoimod = 1.0
++ tnoimod = 1.0
++ tempmod = 0.0
+* Process Parameters
+*(mismatch parameter sky130_fd_pr__special_nfet_01v8__toxe_slope_spectre)
++ toxe = {4.148e-09+MC_MM_SWITCH*AGAUSS(0,1.0,1)*(4.148e-9*1.0*(sky130_fd_pr__special_nfet_01v8__toxe_slope/sqrt(l*w*mult)))}
++ toxm = 4.148e-9
++ dtox = 0.0
++ epsrox = 3.9
++ xj = 1.5e-7
++ ngate = 1.0e+23
++ ndep = 1.7e+17
++ nsd = 1.0e+20
++ rsh = 1.0
++ rshg = 0.1
+* Basic Model Parameters
++ wint = 2.1859e-8
++ lint = 1.1932e-8
+*(mismatch parameter sky130_fd_pr__special_nfet_01v8__vth0_slope_spectre)
++ vth0 = {-2.725906643e-01+MC_MM_SWITCH*AGAUSS(0,1.0,1)*(sky130_fd_pr__special_nfet_01v8__vth0_slope/sqrt(l*w*mult))} lvth0 = 1.126848601e-07 wvth0 = 3.774853372e-07 pvth0 = -5.893905061e-14
++ k1 = 0.90707349
++ k2 = -4.780051754e-01 lk2 = 5.211029248e-08 wk2 = 1.485854542e-07 pk2 = -2.319953847e-14
++ k3 = 2.0
++ k3b = 0.54
++ w0 = 0.0
++ dvt0 = 0.0
++ dvt1 = 0.53
++ dvt2 = -0.032
++ dvt0w = -3.58
++ dvt1w = 1670600.0
++ dvt2w = 0.068
++ dsub = 3.327233912e+00 ldsub = -4.221142868e-07 wdsub = -1.017279859e-06 pdsub = 1.588340081e-13
++ minv = 0.0
++ voffl = 5.8197729e-9
++ lpe0 = 1.0325e-7
++ lpeb = -7.082e-8
++ vbm = -3.0
++ dvtp0 = 0.0
++ dvtp1 = 0.0
++ phin = 0.0
++ cdsc = 0.0
++ cdscb = 0.0
++ cdscd = 0.002052
++ cit = 0.0
+*(mismatch parameter sky130_fd_pr__special_nfet_01v8__voff_slope_spectre)
++ voff = {-7.647793840e-01+MC_MM_SWITCH*AGAUSS(0,1.0,1)*(sky130_fd_pr__special_nfet_01v8__voff_slope/sqrt(l*w*mult))} lvoff = 7.028920830e-8
++ nfactor = -3.213434603e+00 lnfactor = 8.137987257e-07 wnfactor = 2.475245621e-07 pnfactor = -3.864749502e-14
++ eta0 = 0.0
++ etab = -0.043998
++ u0 = 8.608557677e-02 lu0 = -9.619394811e-09 wu0 = -4.705922369e-08 pu0 = 7.347638951e-15
++ ua = -1.393966070e-09 lua = 3.574422544e-17 wua = 1.398486904e-16 pua = -2.183541512e-23
++ ub = 6.496924862e-18 lub = -7.119777965e-25 wub = -2.980183442e-24 pub = 4.653139219e-31
++ uc = -1.261952913e-10 luc = 3.398367043e-17 wuc = 1.186133774e-16 puc = -1.851981829e-23
++ ud = 0.0
++ up = 0.0
++ lp = 1.0
++ eu = 1.67
++ vtl = 0.0
++ xn = 3.0
++ vsat = 3.539574068e+05 lvsat = -2.635347827e-02 wvsat = -8.318022480e-02 pvsat = 1.298742758e-8
++ a0 = 1.5
++ ags = 1.25
++ a1 = 0.0
++ a2 = 0.42385546
++ b0 = 0.0
++ b1 = 0.0
++ keta = -1.038255847e+00 lketa = 1.514331597e-07 wketa = 4.029564638e-07 pketa = -6.291601043e-14
++ dwg = 0.0
++ dwb = 0.0
++ pclm = 1.737607849e-02 lpclm = 2.557100501e-08 wpclm = 1.207637111e-07 ppclm = -1.885556280e-14
++ pdiblc1 = 0.35697215
++ pdiblc2 = 0.0084061121
++ pdiblcb = -0.10329577
++ drout = 0.50332666
++ pscbe1 = 791419880.0
++ pscbe2 = 1.0e-12
++ pvag = 0.0
++ delta = 0.01
++ fprout = 0.0
++ pdits = 0.0
++ pditsl = 0.0
++ pditsd = 0.0
++ lambda = 0.0
++ lc = 5.0e-9
+* Parameters FOR Asymmetric AND Bias-Dependent RDS Model
++ rdsw = 65.968
++ rsw = 0.0
++ rdw = 0.0
++ rdswmin = 0.0
++ rdwmin = 0.0
++ rswmin = 0.0
++ prwb = 0.0
++ prwg = 0.021507
++ wr = 1.0
+* Impact Ionization Current Model Parameters
++ alpha0 = 1.424179200e-07 lalpha0 = -1.417994676e-14 walpha0 = 2.191742220e-22 palpha0 = -3.422097810e-29
++ alpha1 = 0.85
++ beta0 = 1.671249334e+01 lbeta0 = -3.610634598e-07 wbeta0 = 3.836930773e-17 pbeta0 = -5.989875262e-24
+* Gidl Induced Drain Leakage Model Parameters
++ agidl = 0.0
++ bgidl = 2300000000.0
++ cgidl = 0.5
++ egidl = 0.8
+* Gate Dielectric Tunneling Current Model Parameters
++ toxref = 4.148e-9
++ dlcig = 0.0
++ aigbacc = 1.0
++ bigbacc = 0.0
++ cigbacc = 0.0
++ nigbacc = 0.0
++ aigbinv = 0.35
++ bigbinv = 0.03
++ cigbinv = 0.006
++ eigbinv = 1.1
++ nigbinv = 0.0
++ aigc = 0.43
++ bigc = 0.054
++ cigc = 0.075
++ aigsd = 0.43
++ bigsd = 0.054
++ cigsd = 0.075
++ nigc = 0.0
++ poxedge = 1.0
++ pigcd = 1.0
++ ntox = 1.0
++ vfbsdoff = 0.0
+* Charge AND Capacitance Model Parameters
++ dlc = 9.87909e-9
++ dwc = 0.0
++ xpart = 0.0
++ cgso = 2.449068e-10
++ cgdo = 2.449068e-10
++ cgbo = 1.0e-13
++ cgdl = 0.0
++ cgsl = 0.0
++ clc = 1.0e-7
++ cle = 0.6
++ cf = 1.4067e-12
++ ckappas = 0.6
++ vfbcv = -1.0
++ acde = 0.4
++ moin = 6.9
++ noff = 3.4037
++ voffcv = -0.17287
+* High-Speed/RF Model Parameters
++ xrcrg1 = 12.0
++ xrcrg2 = 1.0
++ rbpb = 50.0
++ rbpd = 50.0
++ rbps = 50.0
++ rbdb = 50.0
++ rbsb = 50.0
++ gbmin = 1.0e-12
+* Flicker AND Thermal Noise Model Parameters
++ ef = 0.84
++ noia = 2.5e+42
++ noib = 0.0
++ noic = 0.0
++ em = 41000000.0
++ ntnoi = 1.0
++ lintnoi = -1.0e-7
++ af = 1.0
++ kf = 0.0
++ tnoia = 15000000.0
++ tnoib = 9900000.0
++ rnoia = 0.94
++ rnoib = 0.26
+* Layout-Dependent Parasitics Model Parameters
++ xl = 0.0
++ xw = 0.0
++ dmcg = 0.0
++ dmdg = 0.0
++ dmcgt = 0.0
++ xgw = 0.0
++ xgl = 0.0
++ ngcon = 1.0
+* Asymmetric Source/Drain Junction Diode Model Parameters
++ jss = 0.00275
++ jsws = 6.0e-10
++ ijthsfwd = 0.1
++ ijthsrev = 0.1
++ bvs = 11.7
++ xjbvs = 1.0
++ pbs = 0.729
++ cjs = 0.001339749237
++ mjs = 0.44
++ pbsws = 0.2
++ cjsws = 3.67354204e-11
++ mjsws = 0.0009
++ pbswgs = 0.95578
++ cjswgs = 2.38232788e-10
++ mjswgs = 0.8
+* Temperature Dependence Parameters
++ tnom = 30.0
++ kt1 = -1.368700733e-01 lkt1 = -1.312958033e-08 wkt1 = -8.156852971e-17 pkt1 = 1.273581240e-23
++ kt2 = -0.028878939
++ at = 1.675153666e+03 lat = 6.564790165e-03 wat = -2.587959170e-11 pat = 4.040746717e-18
++ ute = -9.418347116e-01 lute = -5.265038454e-08 wute = -2.218108973e-07 pute = 3.463266627e-14
++ ua1 = -2.3847336e-11
++ ub1 = 7.0775317e-19
++ uc1 = 1.4718625e-10
++ kt1l = 0.0
++ prt = 0.0
++ tvoff = -3.957110784e-03 ltvoff = 4.991341259e-10
++ njs = 1.2928
++ tpb = 0.0012287
++ tcj = 0.000792
++ tpbsw = 0.0
++ tcjsw = 1.0e-5
++ tpbswg = 0.0
++ tcjswg = 0.0
++ xtis = 2.0
++ tvfbsdoff = 0.0
+* DW AND DL Parameters
++ ll = 0.0
++ wl = 0.0
++ lln = 1.0
++ wln = 1.0
++ lw = 0.0
++ ww = 0.0
++ lwn = 1.0
++ wwn = 1.0
++ lwl = 0.0
++ wwl = 0.0
++ llc = 0.0
++ wlc = 0.0
++ lwc = 0.0
++ wwc = 0.0
++ lwlc = 0.0
++ wwlc = 0.0
+* Stress Parameters
++ saref = 1.04e-6
++ sbref = 1.04e-6
++ kvth0 = 9.8e-9
++ lkvth0 = 0.0
++ wkvth0 = 2.0e-7
++ pkvth0 = 0.0
++ llodvth = 0.0
++ wlodvth = 1.0
++ wlod = 0.0
++ stk2 = 0.0
++ lodk2 = 1.0
++ lodeta0 = 1.0
++ ku0 = -2.7e-8
++ lku0 = 0.0
++ wku0 = 0.0
++ pku0 = 0.0
++ tku0 = 0.0
++ llodku0 = 0.0
++ wlodku0 = 1.0
++ kvsat = 0.2
++ steta0 = 0.0
+.ends sky130_fd_pr__special_nfet_01v8
+* Well Proximity Effect Parameters

--- a/cells/special_nfet_01v8/sky130_fd_pr__special_nfet_01v8__wafer.corner.spice
+++ b/cells/special_nfet_01v8/sky130_fd_pr__special_nfet_01v8__wafer.corner.spice
@@ -1,0 +1,72 @@
+* Copyright 2020 The SkyWater PDK Authors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+
+* SKY130 Spice File.
+* Number of bins: 2
+.param
++ sky130_fd_pr__special_nfet_01v8__toxe_mult = 1.0
++ sky130_fd_pr__special_nfet_01v8__rshn_mult = 1.0
++ sky130_fd_pr__special_nfet_01v8__overlap_mult = 1.0
++ sky130_fd_pr__special_nfet_01v8__lint_diff = 0.0
++ sky130_fd_pr__special_nfet_01v8__wint_diff = 0.0
++ sky130_fd_pr__special_nfet_01v8__dlc_diff = 0.0
++ sky130_fd_pr__special_nfet_01v8__dwc_diff = 0.0
+*
+* sky130_fd_pr__special_nfet_01v8, Bin 000, W = 0.36, L = 0.15
+* -----------------------------------
++ sky130_fd_pr__special_nfet_01v8__nfactor_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__keta_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__ua_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__eta0_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__pclm_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__ub_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__tvoff_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__ags_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__b0_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__b1_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__rdsw_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__a0_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__u0_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__voff_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__k2_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__kt1_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__pdits_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__pditsd_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__vsat_diff_0 = 0.0
++ sky130_fd_pr__special_nfet_01v8__vth0_diff_0 = 0.0
+*
+* sky130_fd_pr__special_nfet_01v8, Bin 001, W = 0.39, L = 0.15
+* -----------------------------------
++ sky130_fd_pr__special_nfet_01v8__nfactor_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__keta_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__ua_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__eta0_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__pclm_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__ub_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__tvoff_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__ags_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__b0_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__b1_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__rdsw_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__a0_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__u0_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__voff_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__k2_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__kt1_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__pdits_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__pditsd_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__vsat_diff_1 = 0.0
++ sky130_fd_pr__special_nfet_01v8__vth0_diff_1 = 0.0
+*
+.include "sky130_fd_pr__special_nfet_01v8.pm3.spice"

--- a/cells/special_pfet_01v8_hvt/sky130_fd_pr__special_pfet_01v8_hvt.pm3.spice
+++ b/cells/special_pfet_01v8_hvt/sky130_fd_pr__special_pfet_01v8_hvt.pm3.spice
@@ -1,0 +1,306 @@
+* Copyright 2020 The SkyWater PDK Authors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+
+* SKY130 Spice File.
+.param sky130_fd_pr__special_pfet_01v8_hvt__toxe_slope_spectre = 0.0
+.param sky130_fd_pr__special_pfet_01v8_hvt__vth0_slope_spectre = 0.0
+.param sky130_fd_pr__special_pfet_01v8_hvt__voff_slope_spectre = 0.0
+.param sky130_fd_pr__special_pfet_01v8_hvt__nfactor_slope_spectre = 0.0
+* statistics {
+*   process {
+*   }
+*   mismatch {
+*     vary sky130_fd_pr__special_pfet_01v8_hvt__toxe_slope_spectre dist=gauss std = 1.0
+*     vary sky130_fd_pr__special_pfet_01v8_hvt__vth0_slope_spectre dist=gauss std = 1.0
+*     vary sky130_fd_pr__special_pfet_01v8_hvt__voff_slope_spectre dist=gauss std = 1.0
+*     vary sky130_fd_pr__special_pfet_01v8_hvt__nfactor_slope_spectre dist=gauss std = 1.0
+*   }
+* }
+.subckt  sky130_fd_pr__special_pfet_01v8_hvt d g s b
++ 
+.param  l = 1 w = 1 nf = 1.0 ad = 0 as = 0 pd = 0 ps = 0 nrd = 0 nrs = 0 sa = 0 sb = 0 sd = 0 mult = 1
+msky130_fd_pr__special_pfet_01v8_hvt d g s b sky130_fd_pr__special_pfet_01v8_hvt__model l = {l} w = {w} nf = {nf} ad = {ad} as = {as} pd = {pd} ps = {ps} nrd = {nrd} nrs = {nrs} sa = {sa} sb = {sb} sd = {sd}
+.model sky130_fd_pr__special_pfet_01v8_hvt__model.0 pmos
+* Model Flag Parameters
++ lmin = 1.49e-07 lmax = 1.51e-07 wmin = 3.59e-07 wmax = 3.61e-7
++ level = 54.0
++ version = 4.5
++ binunit = 2.0
++ mobmod = 0.0
++ capmod = 2.0
++ igcmod = 0.0
++ igbmod = 0.0
++ geomod = 0.0
++ diomod = 1.0
++ rdsmod = 0.0
++ rbodymod = 1.0
++ rgatemod = 0.0
++ permod = 1.0
++ acnqsmod = 0.0
++ trnqsmod = 0.0
++ fnoimod = 1.0
++ tnoimod = 1.0
++ tempmod = 0.0
+* Process Parameters
+*(mismatch parameter sky130_fd_pr__special_pfet_01v8_hvt__toxe_slope_spectre)
++ toxe = {4.23e-09*sky130_fd_pr__special_pfet_01v8_hvt__toxe_mult+MC_MM_SWITCH*AGAUSS(0,1.0,1)*(4.23e-9*sky130_fd_pr__special_pfet_01v8_hvt__toxe_mult*(sky130_fd_pr__special_pfet_01v8_hvt__toxe_slope/sqrt(l*w*mult)))}
++ toxm = 4.23e-9
++ dtox = 0.0
++ epsrox = 3.9
++ xj = 1.5e-7
++ ngate = 1.0e+23
++ ndep = 1.7e+17
++ nsd = 1.0e+20
++ rsh = {1.0*sky130_fd_pr__special_pfet_01v8_hvt__rshp_mult}
++ rshg = 0.1
+* Basic Model Parameters
++ wint = {9.364e-09+sky130_fd_pr__special_pfet_01v8_hvt__wint_diff}
++ lint = {-2.026e-08+sky130_fd_pr__special_pfet_01v8_hvt__lint_diff}
+*(mismatch parameter sky130_fd_pr__special_pfet_01v8_hvt__vth0_slope_spectre)
++ vth0 = {-1.0751186382512+sky130_fd_pr__special_pfet_01v8_hvt__vth0_diff_0+MC_MM_SWITCH*AGAUSS(0,1.0,1)*(sky130_fd_pr__special_pfet_01v8_hvt__vth0_slope/sqrt(l*w*mult))}
++ k1 = 0.915817576187918
++ k2 = {-0.191354581465138+sky130_fd_pr__special_pfet_01v8_hvt__k2_diff_0}
++ k3 = -13.778
++ k3b = 2.0
++ w0 = 0.0
++ dvt0 = 4.05
++ dvt1 = 0.3
++ dvt2 = 0.03
++ dvt0w = -4.254
++ dvt1w = 1147200.0
++ dvt2w = -0.00896
++ dsub = 0.632029034401906
++ minv = 0.0
++ voffl = 0.0
++ lpe0 = 0.0
++ lpeb = 0.0
++ vbm = -3.0
++ dvtp0 = 0.0
++ dvtp1 = 0.0
++ phin = 0.0
++ cdsc = 0.0
++ cdscb = 0.0
++ cdscd = 0.0
++ cit = 1.0e-5
+*(mismatch parameter sky130_fd_pr__special_pfet_01v8_hvt__voff_slope_spectre)
++ voff = {-0.252068561266462+sky130_fd_pr__special_pfet_01v8_hvt__voff_diff_0+MC_MM_SWITCH*AGAUSS(0,1.0,1)*(sky130_fd_pr__special_pfet_01v8_hvt__voff_slope/sqrt(l*w*mult))}
+*(mismatch parameter sky130_fd_pr__special_pfet_01v8_hvt__nfactor_slope_spectre)
++ nfactor = {3.06838122728761+sky130_fd_pr__special_pfet_01v8_hvt__nfactor_diff_0+MC_MM_SWITCH*AGAUSS(0,1.0,1)*(sky130_fd_pr__special_pfet_01v8_hvt__nfactor_slope/sqrt(l*w*mult))}
++ eta0 = {0.709002668530266+sky130_fd_pr__special_pfet_01v8_hvt__eta0_diff_0}
++ etab = 0.0119734813782515
++ u0 = {0.00388572612584648+sky130_fd_pr__special_pfet_01v8_hvt__u0_diff_0}
++ ua = {-2.00244775464247e-09+sky130_fd_pr__special_pfet_01v8_hvt__ua_diff_0}
++ ub = {1.8126637343077e-18+sky130_fd_pr__special_pfet_01v8_hvt__ub_diff_0}
++ uc = -3.29420596540557e-11
++ ud = 0.0
++ up = 0.0
++ lp = 1.0
++ eu = 1.67
++ vtl = 0.0
++ xn = 3.0
++ vsat = {123538.047249085+sky130_fd_pr__special_pfet_01v8_hvt__vsat_diff_0}
++ a0 = {0.999069843161314+sky130_fd_pr__special_pfet_01v8_hvt__a0_diff_0}
++ ags = {1.24999999958161+sky130_fd_pr__special_pfet_01v8_hvt__ags_diff_0}
++ a1 = 0.0
++ a2 = 0.402340703539025
++ b0 = {0.0+sky130_fd_pr__special_pfet_01v8_hvt__b0_diff_0}
++ b1 = {0.0+sky130_fd_pr__special_pfet_01v8_hvt__b1_diff_0}
++ keta = {-0.059104614991198+sky130_fd_pr__special_pfet_01v8_hvt__keta_diff_0}
++ dwg = -5.722e-9
++ dwb = -1.7864e-8
++ pclm = {0.626485556768748+sky130_fd_pr__special_pfet_01v8_hvt__pclm_diff_0}
++ pdiblc1 = 0.156960184691247
++ pdiblc2 = 0.00484688249504905
++ pdiblcb = -0.816101282025912
++ drout = 0.999999999574636
++ pscbe1 = 813825374.586324
++ pscbe2 = 9.67821053778591e-9
++ pvag = 0.0
++ delta = 0.01
++ fprout = 0.0
++ pdits = {0.0+sky130_fd_pr__special_pfet_01v8_hvt__pdits_diff_0}
++ pditsl = 0.0
++ pditsd = {0.0+sky130_fd_pr__special_pfet_01v8_hvt__pditsd_diff_0}
++ lambda = 0.0
++ lc = 5.0e-9
+* Parameters FOR Asymmetric AND Bias-Dependent RDS Model
++ rdsw = {531.92+sky130_fd_pr__special_pfet_01v8_hvt__rdsw_diff_0}
++ rsw = 0.0
++ rdw = 0.0
++ rdswmin = 0.0
++ rdwmin = 0.0
++ rswmin = 0.0
++ prwb = -0.32348
++ prwg = 0.02
++ wr = 1.0
+* Impact Ionization Current Model Parameters
++ alpha0 = 1.0e-10
++ alpha1 = 1.0e-10
++ beta0 = 8.66184153982975
+* Gidl Induced Drain Leakage Model Parameters
++ agidl = {0.0+sky130_fd_pr__special_pfet_01v8_hvt__agidl_diff_0}
++ bgidl = {1000000000.29118+sky130_fd_pr__special_pfet_01v8_hvt__bgidl_diff_0}
++ cgidl = {300.0+sky130_fd_pr__special_pfet_01v8_hvt__cgidl_diff_0}
++ egidl = 0.1
+* Gate Dielectric Tunneling Current Model Parameters
++ toxref = 4.23e-9
++ dlcig = 0.0
++ aigbacc = 0.43
++ bigbacc = 0.054
++ cigbacc = 0.075
++ nigbacc = 1.0
++ aigbinv = 0.35
++ bigbinv = 0.03
++ cigbinv = 0.006
++ eigbinv = 1.1
++ nigbinv = 3.0
++ aigc = 0.43
++ bigc = 0.054
++ cigc = 0.075
++ aigsd = 0.43
++ bigsd = 0.054
++ cigsd = 0.075
++ nigc = 1.0
++ poxedge = 1.0
++ pigcd = 1.0
++ ntox = 1.0
++ vfbsdoff = 0.0
+* Charge AND Capacitance Model Parameters
++ dlc = {-1.106e-08+sky130_fd_pr__special_pfet_01v8_hvt__dlc_diff+sky130_fd_pr__special_pfet_01v8_hvt__dlc_rotweak}
++ dwc = {0.0+sky130_fd_pr__special_pfet_01v8_hvt__dwc_diff}
++ xpart = 0.0
++ cgso = {6.0e-11*sky130_fd_pr__special_pfet_01v8_hvt__overlap_mult}
++ cgdo = {6.0e-11*sky130_fd_pr__special_pfet_01v8_hvt__overlap_mult}
++ cgbo = 0.0
++ cgdl = {7.6e-12*sky130_fd_pr__special_pfet_01v8_hvt__overlap_mult}
++ cgsl = {7.6e-12*sky130_fd_pr__special_pfet_01v8_hvt__overlap_mult}
++ clc = 1.0e-7
++ cle = 0.6
++ cf = 1.2e-11
++ ckappas = 0.6
++ vfbcv = -0.1446893
++ acde = 0.552
++ moin = 14.504
++ noff = 4.0
++ voffcv = -0.1375
+* High-Speed/RF Model Parameters
++ xrcrg1 = 12.0
++ xrcrg2 = 1.0
++ rbpb = 50.0
++ rbpd = 50.0
++ rbps = 50.0
++ rbdb = 50.0
++ rbsb = 50.0
++ gbmin = 1.0e-12
+* Flicker AND Thermal Noise Model Parameters
++ ef = 0.88
++ noia = 1.2e+41
++ noib = 2.0e+25
++ noic = 0.0
++ em = 41000000.0
++ ntnoi = 1.0
++ lintnoi = -6.0e-8
++ af = 1.0
++ kf = 0.0
++ tnoia = 1.5
++ tnoib = 3.5
++ rnoia = 0.577
++ rnoib = 0.37
+* Layout-Dependent Parasitics Model Parameters
++ xl = 0.0
++ xw = 0.0
++ dmcg = 0.0
++ dmdg = 0.0
++ dmcgt = 0.0
++ xgw = 0.0
++ xgl = 0.0
++ ngcon = 1.0
+* Asymmetric Source/Drain Junction Diode Model Parameters
++ jss = 2.17e-5
++ jsws = 8.2e-10
++ ijthsfwd = 0.1
++ ijthsrev = 0.1
++ bvs = 12.8
++ xjbvs = 1.0
++ pbs = 0.6587
++ cjs = {0.00075561*sky130_fd_pr__special_pfet_01v8_hvt__ajunction_mult}
++ mjs = 0.34629
++ pbsws = 0.7418
++ cjsws = {9.2435e-11*sky130_fd_pr__special_pfet_01v8_hvt__pjunction_mult}
++ mjsws = 0.26859
++ pbswgs = 1.3925
++ cjswgs = {2.4701e-10*sky130_fd_pr__special_pfet_01v8_hvt__pjunction_mult}
++ mjswgs = 0.70393
+* Temperature Dependence Parameters
++ tnom = 30.0
++ kt1 = {-0.486150550825388+sky130_fd_pr__special_pfet_01v8_hvt__kt1_diff_0}
++ kt2 = -0.0168844133026869
++ at = 23782.3869663337
++ ute = -0.163199999725863
++ ua1 = 9.15790453404767e-10
++ ub1 = -6.16621741789699e-19
++ uc1 = -1.12531129150376e-10
++ kt1l = 0.0
++ prt = 0.0
++ tvoff = {0.0+sky130_fd_pr__special_pfet_01v8_hvt__tvoff_diff_0}
++ njs = 1.2556
++ tpb = 0.0019551
++ tcj = 0.0012407
++ tpbsw = 0.00014242
++ tcjsw = 0.0
++ tpbswg = 0.0
++ tcjswg = 2.0e-12
++ xtis = 2.0
++ tvfbsdoff = 0.0
+* DW AND DL Parameters
++ ll = 0.0
++ wl = 0.0
++ lln = 1.0
++ wln = 1.0
++ lw = 0.0
++ ww = 0.0
++ lwn = 1.0
++ wwn = 1.0
++ lwl = 0.0
++ wwl = 0.0
++ llc = 0.0
++ wlc = 0.0
++ lwc = 0.0
++ wwc = 0.0
++ lwlc = 0.0
++ wwlc = 0.0
+* Stress Parameters
++ saref = 1.04e-6
++ sbref = 1.04e-6
++ kvth0 = 2.65e-8
++ lkvth0 = 0.0
++ wkvth0 = 2.5e-7
++ pkvth0 = 0.0
++ llodvth = 0.0
++ wlodvth = 1.0
++ wlod = 0.0
++ stk2 = 0.0
++ lodk2 = 1.0
++ lodeta0 = 1.0
++ ku0 = 4.5e-8
++ lku0 = 0.0
++ wku0 = 2.5e-7
++ pku0 = 0.0
++ tku0 = 0.0
++ llodku0 = 0.0
++ wlodku0 = 1.0
++ kvsat = 0.4
++ steta0 = 0.0
+* Well Proximity Effect Parameters
+.ends sky130_fd_pr__special_pfet_01v8_hvt

--- a/cells/special_pfet_01v8_hvt/sky130_fd_pr__special_pfet_01v8_hvt__ff.corner.spice
+++ b/cells/special_pfet_01v8_hvt/sky130_fd_pr__special_pfet_01v8_hvt__ff.corner.spice
@@ -1,0 +1,52 @@
+* Copyright 2020 The SkyWater PDK Authors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+
+* SKY130 Spice File.
+* Number of bins: 1
+.param
++ sky130_fd_pr__special_pfet_01v8_hvt__toxe_mult = 0.9635
++ sky130_fd_pr__special_pfet_01v8_hvt__rshp_mult = 1.0
++ sky130_fd_pr__special_pfet_01v8_hvt__overlap_mult = 0.91216
++ sky130_fd_pr__special_pfet_01v8_hvt__lint_diff = 1.21275e-8
++ sky130_fd_pr__special_pfet_01v8_hvt__wint_diff = -2.252e-8
++ sky130_fd_pr__special_pfet_01v8_hvt__dlc_diff = 1.21275e-8
++ sky130_fd_pr__special_pfet_01v8_hvt__dwc_diff = -2.252e-8
+*
+* sky130_fd_pr__special_pfet_01v8_hvt, Bin 000, W = 0.36, L = 0.15
+* ------------------------------------
++ sky130_fd_pr__special_pfet_01v8_hvt__k2_diff_0 = -0.012919
++ sky130_fd_pr__special_pfet_01v8_hvt__rdsw_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__pdits_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__ua_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__pclm_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__ub_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__kt1_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__bgidl_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__tvoff_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__cgidl_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__ags_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__a0_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__voff_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__pditsd_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__agidl_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__keta_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__b0_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__b1_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__vsat_diff_0 = 5500.8
++ sky130_fd_pr__special_pfet_01v8_hvt__eta0_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__u0_diff_0 = -0.00052794
++ sky130_fd_pr__special_pfet_01v8_hvt__nfactor_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__vth0_diff_0 = 0.067192
+*
+.include "sky130_fd_pr__special_pfet_01v8_hvt__ff.pm3.spice"

--- a/cells/special_pfet_01v8_hvt/sky130_fd_pr__special_pfet_01v8_hvt__ff.pm3.spice
+++ b/cells/special_pfet_01v8_hvt/sky130_fd_pr__special_pfet_01v8_hvt__ff.pm3.spice
@@ -1,0 +1,306 @@
+* Copyright 2020 The SkyWater PDK Authors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+
+* SKY130 Spice File.
+.param sky130_fd_pr__special_pfet_01v8_hvt__toxe_slope_spectre = 0.0
+.param sky130_fd_pr__special_pfet_01v8_hvt__vth0_slope_spectre = 0.0
+.param sky130_fd_pr__special_pfet_01v8_hvt__voff_slope_spectre = 0.0
+.param sky130_fd_pr__special_pfet_01v8_hvt__nfactor_slope_spectre = 0.0
+* statistics {
+*   process {
+*   }
+*   mismatch {
+*     vary sky130_fd_pr__special_pfet_01v8_hvt__toxe_slope_spectre dist=gauss std = 1.0
+*     vary sky130_fd_pr__special_pfet_01v8_hvt__vth0_slope_spectre dist=gauss std = 1.0
+*     vary sky130_fd_pr__special_pfet_01v8_hvt__voff_slope_spectre dist=gauss std = 1.0
+*     vary sky130_fd_pr__special_pfet_01v8_hvt__nfactor_slope_spectre dist=gauss std = 1.0
+*   }
+* }
+.subckt  sky130_fd_pr__special_pfet_01v8_hvt d g s b
++ 
+.param  l = 1 w = 1 nf = 1.0 ad = 0 as = 0 pd = 0 ps = 0 nrd = 0 nrs = 0 sa = 0 sb = 0 sd = 0 mult = 1
+msky130_fd_pr__special_pfet_01v8_hvt d g s b sky130_fd_pr__special_pfet_01v8_hvt__model l = {l} w = {w} nf = {nf} ad = {ad} as = {as} pd = {pd} ps = {ps} nrd = {nrd} nrs = {nrs} sa = {sa} sb = {sb} sd = {sd}
+.model sky130_fd_pr__special_pfet_01v8_hvt__model.0 pmos
+* Model Flag Parameters
++ lmin = 1.5e-07 lmax = 1.8e-07 wmin = 3.6e-07 wmax = 4.2e-7
++ level = 54.0
++ version = 4.5
++ binunit = 2.0
++ mobmod = 0.0
++ capmod = 2.0
++ igcmod = 0.0
++ igbmod = 0.0
++ geomod = 0.0
++ diomod = 1.0
++ rdsmod = 0.0
++ rbodymod = 1.0
++ rgatemod = 0.0
++ permod = 1.0
++ acnqsmod = 0.0
++ trnqsmod = 0.0
++ fnoimod = 1.0
++ tnoimod = 1.0
++ tempmod = 0.0
+* Process Parameters
+*(mismatch parameter sky130_fd_pr__special_pfet_01v8_hvt__toxe_slope_spectre)
++ toxe = {4.075605e-09+MC_MM_SWITCH*AGAUSS(0,1.0,1)*(4.23e-9*0.9635*(sky130_fd_pr__special_pfet_01v8_hvt__toxe_slope/sqrt(l*w*mult)))}
++ toxm = 4.23e-9
++ dtox = 0.0
++ epsrox = 3.9
++ xj = 1.5e-7
++ ngate = 1.0e+23
++ ndep = 1.7e+17
++ nsd = 1.0e+20
++ rsh = 1.0
++ rshg = 0.1
+* Basic Model Parameters
++ wint = -1.3156e-8
++ lint = -8.1325e-9
+*(mismatch parameter sky130_fd_pr__special_pfet_01v8_hvt__vth0_slope_spectre)
++ vth0 = {9.612074778e-01+MC_MM_SWITCH*AGAUSS(0,1.0,1)*(sky130_fd_pr__special_pfet_01v8_hvt__vth0_slope/sqrt(l*w*mult))} lvth0 = -3.972363322e-07 wvth0 = -8.993117806e-07 pvth0 = 1.765034266e-13
++ k1 = -1.820663869e+00 lk1 = 5.244804765e-07 wk1 = 8.949482650e-07 pk1 = -1.756470212e-13
++ k2 = 1.570841132e-03 lk2 = -2.737854379e-08 wk2 = 8.815870511e-08 pk2 = -1.730246826e-14
++ k3 = -13.778
++ k3b = 2.0
++ w0 = 0.0
++ dvt0 = 4.05
++ dvt1 = 0.3
++ dvt2 = 0.03
++ dvt0w = -4.254
++ dvt1w = 1147200.0
++ dvt2w = -0.00896
++ dsub = 6.812528741e+00 ldsub = -1.207106892e-06 wdsub = -2.311512125e-06 pdsub = 4.536689273e-13
++ minv = 0.0
++ voffl = 0.0
++ lpe0 = 0.0
++ lpeb = 0.0
++ vbm = -3.0
++ dvtp0 = 0.0
++ dvtp1 = 0.0
++ phin = 0.0
++ cdsc = 0.0
++ cdscb = 0.0
++ cdscd = 0.0
++ cit = 1.0e-5
+*(mismatch parameter sky130_fd_pr__special_pfet_01v8_hvt__voff_slope_spectre)
++ voff = {3.991766327e+00+MC_MM_SWITCH*AGAUSS(0,1.0,1)*(sky130_fd_pr__special_pfet_01v8_hvt__voff_slope/sqrt(l*w*mult))} lvoff = -8.522401940e-07 wvoff = -1.888280002e-06 pvoff = 3.706032746e-13
+*(mismatch parameter sky130_fd_pr__special_pfet_01v8_hvt__nfactor_slope_spectre)
++ nfactor = {-1.035637660e+01+MC_MM_SWITCH*AGAUSS(0,1.0,1)*(sky130_fd_pr__special_pfet_01v8_hvt__nfactor_slope/sqrt(l*w*mult))} lnfactor = 2.655559853e-06 wnfactor = 5.453341069e-06 pnfactor = -1.070299985e-12
++ eta0 = 8.304765258e+00 leta0 = -1.533764903e-06 weta0 = -3.487823512e-06 peta0 = 6.845376816e-13
++ etab = 4.529799288e-01 letab = -8.890533237e-08 wetab = -2.006426673e-07 petab = 3.937913310e-14
++ u0 = -4.022000678e-02 lu0 = 8.719211341e-09 wu0 = 1.897757190e-08 pu0 = -3.724633148e-15
++ ua = -3.838169482e-09 lua = 3.597177269e-16 wua = 7.018188546e-16 pua = -1.377424775e-22
++ ub = -6.681557303e-18 lub = 1.704970974e-24 wub = 3.768851024e-24 pub = -7.396935462e-31
++ uc = -3.838682792e-10 luc = 7.539055223e-17 wuc = 2.194742047e-16 puc = -4.307510479e-23
++ ud = 0.0
++ up = 0.0
++ lp = 1.0
++ eu = 1.67
++ vtl = 0.0
++ xn = 3.0
++ vsat = 2.212857852e+06 lvsat = -4.123448854e-01 wvsat = -8.483246505e-01 pvsat = 1.664964375e-7
++ a0 = 1.849664763e+00 la0 = -1.341176413e-07 wa0 = 9.408658508e-08 pa0 = -1.846590362e-14
++ ags = 1.249999985e+00 lags = 2.930155674e-15 wags = 6.663256613e-15 pags = -1.307763675e-21
++ a1 = 0.0
++ a2 = -8.824942107e+00 la2 = 1.820836380e-06 wa2 = 3.691368309e-06 pa2 = -7.244864011e-13
++ b0 = 0.0
++ b1 = 0.0
++ keta = -1.583060888e+00 lketa = 3.051610943e-07 wketa = 6.667810102e-07 pketa = -1.308657750e-13
++ dwg = -5.722e-9
++ dwb = -1.7864e-8
++ pclm = 2.014970397e+00 lpclm = -2.332238735e-07 wpclm = -3.048570274e-08 ppclm = 5.983276449e-15
++ pdiblc1 = 9.939370838e-02 lpdiblc1 = 1.734479016e-08 wpdiblc1 = 1.000998774e-07 ppdiblc1 = -1.964610244e-14
++ pdiblc2 = 6.397470244e-02 lpdiblc2 = -1.124211689e-08 wpdiblc2 = -1.817250159e-08 ppdiblc2 = 3.566626025e-15
++ pdiblcb = -9.722820553e+00 lpdiblcb = 1.864089751e-06 wpdiblcb = 4.934673143e-06 ppdiblcb = -9.685036244e-13
++ drout = 9.875979995e-01 ldrout = 2.062019073e-09 wdrout = 6.774321548e-15 pdrout = -1.329562238e-21
++ pscbe1 = 1.293148691e+09 lpscbe1 = -9.679400029e+01 wpscbe1 = -2.201889440e+02 ppscbe1 = 4.321538309e-5
++ pscbe2 = 1.583191728e-08 lpscbe2 = -1.278555580e-15 wpscbe2 = -3.288925542e-15 ppscbe2 = 6.455009714e-22
++ pvag = 0.0
++ delta = 0.01
++ fprout = 0.0
++ pdits = 0.0
++ pditsl = 0.0
++ pditsd = 0.0
++ lambda = 0.0
++ lc = 5.0e-9
+* Parameters FOR Asymmetric AND Bias-Dependent RDS Model
++ rdsw = 531.92
++ rsw = 0.0
++ rdw = 0.0
++ rdswmin = 0.0
++ rdwmin = 0.0
++ rswmin = 0.0
++ prwb = -0.32348
++ prwg = 0.02
++ wr = 1.0
+* Impact Ionization Current Model Parameters
++ alpha0 = 1.0e-10
++ alpha1 = 1.0e-10
++ beta0 = 2.297034939e+01 lbeta0 = -2.725166000e-06 wbeta0 = -4.457550399e-06 pbeta0 = 8.748611290e-13
+* Gidl Induced Drain Leakage Model Parameters
++ agidl = -1.515150809e-07 lagidl = 3.031143249e-14 wagidl = 6.592771690e-14 pagidl = -1.293930336e-20
++ bgidl = 1.000000010e+09 lbgidl = -2.039252281e-06 wbgidl = -4.637317657e-06 pbgidl = 9.101424217e-13
++ cgidl = 300.0
++ egidl = 0.1
+* Gate Dielectric Tunneling Current Model Parameters
++ toxref = 4.23e-9
++ dlcig = 0.0
++ aigbacc = 0.43
++ bigbacc = 0.054
++ cigbacc = 0.075
++ nigbacc = 1.0
++ aigbinv = 0.35
++ bigbinv = 0.03
++ cigbinv = 0.006
++ eigbinv = 1.1
++ nigbinv = 3.0
++ aigc = 0.43
++ bigc = 0.054
++ cigc = 0.075
++ aigsd = 0.43
++ bigsd = 0.054
++ cigsd = 0.075
++ nigc = 1.0
++ poxedge = 1.0
++ pigcd = 1.0
++ ntox = 1.0
++ vfbsdoff = 0.0
+* Charge AND Capacitance Model Parameters
++ dlc = 1.0675e-9
++ dwc = -2.252e-8
++ xpart = 0.0
++ cgso = 5.47296e-11
++ cgdo = 5.47296e-11
++ cgbo = 0.0
++ cgdl = 6.932416e-12
++ cgsl = 6.932416e-12
++ clc = 1.0e-7
++ cle = 0.6
++ cf = 1.2e-11
++ ckappas = 0.6
++ vfbcv = -0.1446893
++ acde = 0.552
++ moin = 14.504
++ noff = 4.0
++ voffcv = -0.1375
+* High-Speed/RF Model Parameters
++ xrcrg1 = 12.0
++ xrcrg2 = 1.0
++ rbpb = 50.0
++ rbpd = 50.0
++ rbps = 50.0
++ rbdb = 50.0
++ rbsb = 50.0
++ gbmin = 1.0e-12
+* Flicker AND Thermal Noise Model Parameters
++ ef = 0.88
++ noia = 1.2e+41
++ noib = 2.0e+25
++ noic = 0.0
++ em = 41000000.0
++ ntnoi = 1.0
++ lintnoi = -6.0e-8
++ af = 1.0
++ kf = 0.0
++ tnoia = 1.5
++ tnoib = 3.5
++ rnoia = 0.577
++ rnoib = 0.37
+* Layout-Dependent Parasitics Model Parameters
++ xl = 0.0
++ xw = 0.0
++ dmcg = 0.0
++ dmdg = 0.0
++ dmcgt = 0.0
++ xgw = 0.0
++ xgl = 0.0
++ ngcon = 1.0
+* Asymmetric Source/Drain Junction Diode Model Parameters
++ jss = 2.17e-5
++ jsws = 8.2e-10
++ ijthsfwd = 0.1
++ ijthsrev = 0.1
++ bvs = 12.8
++ xjbvs = 1.0
++ pbs = 0.6587
++ cjs = 0.0006938237703
++ mjs = 0.34629
++ pbsws = 0.7418
++ cjsws = 8.8756087e-11
++ mjsws = 0.26859
++ pbswgs = 1.3925
++ cjswgs = 2.37179002e-10
++ mjswgs = 0.70393
+* Temperature Dependence Parameters
++ tnom = 30.0
++ kt1 = 6.379164807e-01 lkt1 = -2.314035949e-07 wkt1 = -5.731658334e-07 pkt1 = 1.124923923e-13
++ kt2 = 1.131417442e+00 lkt2 = -2.303661305e-07 wkt2 = -5.079194445e-07 pkt2 = 9.968680977e-14
++ at = 4.302022427e+03 lat = 1.977153543e-02 wat = 2.128918125e-01 pat = -4.178321157e-8
++ ute = -1.876135489e+00 lute = 2.848012187e-07 wute = -4.365889872e-15 pute = 8.568714627e-22
++ ua1 = -1.881882971e-10 lua1 = 9.450518858e-17 wua1 = -1.146674951e-15 pua1 = 2.250521593e-22
++ ub1 = 4.304954223e-18 lub1 = -8.342008745e-25 wub1 = -2.049391172e-25 pub1 = 4.022237583e-32
++ uc1 = -9.841078859e-10 luc1 = 1.816968155e-16 wuc1 = 4.736713851e-16 puc1 = -9.296511440e-23
++ kt1l = 0.0
++ prt = 0.0
++ tvoff = 0.0
++ njs = 1.2556
++ tpb = 0.0019551
++ tcj = 0.0012407
++ tpbsw = 0.00014242
++ tcjsw = 0.0
++ tpbswg = 0.0
++ tcjswg = 2.0e-12
++ xtis = 2.0
++ tvfbsdoff = 0.0
+* DW AND DL Parameters
++ ll = 0.0
++ wl = 0.0
++ lln = 1.0
++ wln = 1.0
++ lw = 0.0
++ ww = 0.0
++ lwn = 1.0
++ wwn = 1.0
++ lwl = 0.0
++ wwl = 0.0
++ llc = 0.0
++ wlc = 0.0
++ lwc = 0.0
++ wwc = 0.0
++ lwlc = 0.0
++ wwlc = 0.0
+* Stress Parameters
++ saref = 1.04e-6
++ sbref = 1.04e-6
++ kvth0 = 2.65e-8
++ lkvth0 = 0.0
++ wkvth0 = 2.5e-7
++ pkvth0 = 0.0
++ llodvth = 0.0
++ wlodvth = 1.0
++ wlod = 0.0
++ stk2 = 0.0
++ lodk2 = 1.0
++ lodeta0 = 1.0
++ ku0 = 4.5e-8
++ lku0 = 0.0
++ wku0 = 2.5e-7
++ pku0 = 0.0
++ tku0 = 0.0
++ llodku0 = 0.0
++ wlodku0 = 1.0
++ kvsat = 0.4
++ steta0 = 0.0
+* Well Proximity Effect Parameters
+.ends sky130_fd_pr__special_pfet_01v8_hvt

--- a/cells/special_pfet_01v8_hvt/sky130_fd_pr__special_pfet_01v8_hvt__fs.corner.spice
+++ b/cells/special_pfet_01v8_hvt/sky130_fd_pr__special_pfet_01v8_hvt__fs.corner.spice
@@ -1,0 +1,52 @@
+* Copyright 2020 The SkyWater PDK Authors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+
+* SKY130 Spice File.
+* Number of bins: 1
+.param
++ sky130_fd_pr__special_pfet_01v8_hvt__toxe_mult = 0.948
++ sky130_fd_pr__special_pfet_01v8_hvt__rshp_mult = 1.0
++ sky130_fd_pr__special_pfet_01v8_hvt__overlap_mult = 0.91064
++ sky130_fd_pr__special_pfet_01v8_hvt__lint_diff = 1.7325e-8
++ sky130_fd_pr__special_pfet_01v8_hvt__wint_diff = -3.2175e-8
++ sky130_fd_pr__special_pfet_01v8_hvt__dlc_diff = 1.7325e-8
++ sky130_fd_pr__special_pfet_01v8_hvt__dwc_diff = -3.2175e-8
+*
+* sky130_fd_pr__special_pfet_01v8_hvt, Bin 000, W = 0.36, L = 0.15
+* ------------------------------------
++ sky130_fd_pr__special_pfet_01v8_hvt__k2_diff_0 = -0.0066348
++ sky130_fd_pr__special_pfet_01v8_hvt__rdsw_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__pdits_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__ua_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__pclm_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__ub_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__kt1_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__bgidl_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__tvoff_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__cgidl_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__ags_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__a0_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__voff_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__pditsd_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__agidl_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__keta_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__b0_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__b1_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__vsat_diff_0 = -30180.0
++ sky130_fd_pr__special_pfet_01v8_hvt__eta0_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__u0_diff_0 = -0.001025
++ sky130_fd_pr__special_pfet_01v8_hvt__nfactor_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__vth0_diff_0 = 0.08346
+*
+.include "sky130_fd_pr__special_pfet_01v8_hvt__fs.pm3.spice"

--- a/cells/special_pfet_01v8_hvt/sky130_fd_pr__special_pfet_01v8_hvt__fs.pm3.spice
+++ b/cells/special_pfet_01v8_hvt/sky130_fd_pr__special_pfet_01v8_hvt__fs.pm3.spice
@@ -1,0 +1,306 @@
+* Copyright 2020 The SkyWater PDK Authors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+
+* SKY130 Spice File.
+.param sky130_fd_pr__special_pfet_01v8_hvt__toxe_slope_spectre = 0.0
+.param sky130_fd_pr__special_pfet_01v8_hvt__vth0_slope_spectre = 0.0
+.param sky130_fd_pr__special_pfet_01v8_hvt__voff_slope_spectre = 0.0
+.param sky130_fd_pr__special_pfet_01v8_hvt__nfactor_slope_spectre = 0.0
+* statistics {
+*   process {
+*   }
+*   mismatch {
+*     vary sky130_fd_pr__special_pfet_01v8_hvt__toxe_slope_spectre dist=gauss std = 1.0
+*     vary sky130_fd_pr__special_pfet_01v8_hvt__vth0_slope_spectre dist=gauss std = 1.0
+*     vary sky130_fd_pr__special_pfet_01v8_hvt__voff_slope_spectre dist=gauss std = 1.0
+*     vary sky130_fd_pr__special_pfet_01v8_hvt__nfactor_slope_spectre dist=gauss std = 1.0
+*   }
+* }
+.subckt  sky130_fd_pr__special_pfet_01v8_hvt d g s b
++ 
+.param  l = 1 w = 1 nf = 1.0 ad = 0 as = 0 pd = 0 ps = 0 nrd = 0 nrs = 0 sa = 0 sb = 0 sd = 0 mult = 1
+msky130_fd_pr__special_pfet_01v8_hvt d g s b sky130_fd_pr__special_pfet_01v8_hvt__model l = {l} w = {w} nf = {nf} ad = {ad} as = {as} pd = {pd} ps = {ps} nrd = {nrd} nrs = {nrs} sa = {sa} sb = {sb} sd = {sd}
+.model sky130_fd_pr__special_pfet_01v8_hvt__model.0 pmos
+* Model Flag Parameters
++ lmin = 1.5e-07 lmax = 1.8e-07 wmin = 3.6e-07 wmax = 4.2e-7
++ level = 54.0
++ version = 4.5
++ binunit = 2.0
++ mobmod = 0.0
++ capmod = 2.0
++ igcmod = 0.0
++ igbmod = 0.0
++ geomod = 0.0
++ diomod = 1.0
++ rdsmod = 0.0
++ rbodymod = 1.0
++ rgatemod = 0.0
++ permod = 1.0
++ acnqsmod = 0.0
++ trnqsmod = 0.0
++ fnoimod = 1.0
++ tnoimod = 1.0
++ tempmod = 0.0
+* Process Parameters
+*(mismatch parameter sky130_fd_pr__special_pfet_01v8_hvt__toxe_slope_spectre)
++ toxe = {4.01004e-09+MC_MM_SWITCH*AGAUSS(0,1.0,1)*(4.23e-9*0.948*(sky130_fd_pr__special_pfet_01v8_hvt__toxe_slope/sqrt(l*w*mult)))}
++ toxm = 4.23e-9
++ dtox = 0.0
++ epsrox = 3.9
++ xj = 1.5e-7
++ ngate = 1.0e+23
++ ndep = 1.7e+17
++ nsd = 1.0e+20
++ rsh = 1.0
++ rshg = 0.1
+* Basic Model Parameters
++ wint = -2.2811e-8
++ lint = -2.935e-9
+*(mismatch parameter sky130_fd_pr__special_pfet_01v8_hvt__vth0_slope_spectre)
++ vth0 = {1.830266384e+00+MC_MM_SWITCH*AGAUSS(0,1.0,1)*(sky130_fd_pr__special_pfet_01v8_hvt__vth0_slope/sqrt(l*w*mult))} lvth0 = -5.393308720e-07 wvth0 = -1.345007653e-06 pvth0 = 2.499965725e-13
++ k1 = -1.747554175e+00 lk1 = 4.831129388e-07 wk1 = 9.190472936e-07 pk1 = -1.708233205e-13
++ k2 = 1.560235661e-01 lk2 = -5.417234423e-08 wk2 = 1.362421986e-08 pk2 = -2.532333746e-15
++ k3 = -13.778
++ k3b = 2.0
++ w0 = 0.0
++ dvt0 = 4.05
++ dvt1 = 0.3
++ dvt2 = 0.03
++ dvt0w = -4.254
++ dvt1w = 1147200.0
++ dvt2w = -0.00896
++ dsub = 6.670698446e+00 ldsub = -1.116811559e-06 wdsub = -2.373756167e-06 pdsub = 4.412100587e-13
++ minv = 0.0
++ voffl = 0.0
++ lpe0 = 0.0
++ lpeb = 0.0
++ vbm = -3.0
++ dvtp0 = 0.0
++ dvtp1 = 0.0
++ phin = 0.0
++ cdsc = 0.0
++ cdscb = 0.0
++ cdscd = 0.0
++ cit = 1.0e-5
+*(mismatch parameter sky130_fd_pr__special_pfet_01v8_hvt__voff_slope_spectre)
++ voff = {4.695605026e+00+MC_MM_SWITCH*AGAUSS(0,1.0,1)*(sky130_fd_pr__special_pfet_01v8_hvt__voff_slope/sqrt(l*w*mult))} lvoff = -9.440545467e-07 wvoff = -2.337202950e-06 pvoff = 4.344159124e-13
+*(mismatch parameter sky130_fd_pr__special_pfet_01v8_hvt__nfactor_slope_spectre)
++ nfactor = {-3.699298928e+01+MC_MM_SWITCH*AGAUSS(0,1.0,1)*(sky130_fd_pr__special_pfet_01v8_hvt__nfactor_slope/sqrt(l*w*mult))} lnfactor = 7.587416682e-06 wnfactor = 1.815903255e-05 pnfactor = -3.375219380e-12
++ eta0 = 8.182383703e+00 leta0 = -1.429783359e-06 weta0 = -3.581743085e-06 peta0 = 6.657385871e-13
++ etab = 4.457253357e-01 letab = -8.284812984e-08 wetab = -2.060455421e-07 petab = 3.829768491e-14
++ u0 = -9.592712154e-02 lu0 = 1.881094018e-08 wu0 = 4.614461826e-08 pu0 = -8.576900196e-15
++ ua = -1.721190682e-08 lua = 2.900431429e-15 wua = 7.162379237e-15 pua = -1.331271429e-21
++ ub = -6.442381324e-18 lub = 1.554434755e-24 wub = 3.619782649e-24 pub = -6.728090009e-31
++ uc = -3.828960618e-10 luc = 7.121685309e-17 wuc = 2.253841722e-16 puc = -4.189215609e-23
++ ud = 0.0
++ up = 0.0
++ lp = 1.0
++ eu = 1.67
++ vtl = 0.0
++ xn = 3.0
++ vsat = 1.439234038e+06 lvsat = -2.512930872e-01 wvsat = -5.612645236e-01 pvsat = 1.043222370e-7
++ a0 = 1.797062686e+00 la0 = -1.172370724e-07 wa0 = 9.662013410e-08 pa0 = -1.795878433e-14
++ ags = 1.249999985e+00 lags = 2.731505688e-15 wags = 6.842682865e-15 pags = -1.271849293e-21
++ a1 = 0.0
++ a2 = -8.632484378e+00 la2 = 1.688625294e-06 wa2 = 3.790768904e-06 pa2 = -7.045902162e-13
++ b0 = 0.0
++ b1 = 0.0
++ keta = -1.555859553e+00 lketa = 2.839425980e-07 wketa = 6.847359863e-07 pketa = -1.272718778e-13
++ dwg = -5.722e-9
++ dwb = -1.7864e-8
++ pclm = 1.943877222e+00 lpclm = -2.076572915e-07 wpclm = -3.130661704e-08 ppclm = 5.818960909e-15
++ pdiblc1 = 9.440897930e-02 lpdiblc1 = 1.735265047e-08 wpdiblc1 = 1.027953514e-07 ppdiblc1 = -1.910657197e-14
++ pdiblc2 = 6.230151542e-02 lpdiblc2 = -1.033569296e-08 wpdiblc2 = -1.866184791e-08 ppdiblc2 = 3.468677671e-15
++ pdiblcb = -9.647124730e+00 lpdiblcb = 1.751290324e-06 wpdiblcb = 5.067553259e-06 ppdiblcb = -9.419061243e-13
++ drout = 9.882548598e-01 ldrout = 1.830715458e-09 wdrout = 6.956739185e-15 pdrout = -1.293049223e-21
++ pscbe1 = 1.285433399e+09 lpscbe1 = -9.023335140e+01 wpscbe1 = -2.261181578e+02 ppscbe1 = 4.202858199e-5
++ pscbe2 = 1.576995002e-08 lpscbe2 = -1.199320176e-15 wpscbe2 = -3.377489220e-15 ppscbe2 = 6.277739214e-22
++ pvag = 0.0
++ delta = 0.01
++ fprout = 0.0
++ pdits = 0.0
++ pditsl = 0.0
++ pditsd = 0.0
++ lambda = 0.0
++ lc = 5.0e-9
+* Parameters FOR Asymmetric AND Bias-Dependent RDS Model
++ rdsw = 531.92
++ rsw = 0.0
++ rdw = 0.0
++ rdswmin = 0.0
++ rdwmin = 0.0
++ rswmin = 0.0
++ prwb = -0.32348
++ prwg = 0.02
++ wr = 1.0
+* Impact Ionization Current Model Parameters
++ alpha0 = 1.0e-10
++ alpha1 = 1.0e-10
++ beta0 = 2.257026038e+01 lbeta0 = -2.506465477e-06 wbeta0 = -4.577582627e-06 pbeta0 = 8.508352829e-13
+* Gidl Induced Drain Leakage Model Parameters
++ agidl = -1.487813614e-07 lagidl = 2.819789816e-14 wagidl = 6.770300827e-14 pagidl = -1.258395815e-20
++ bgidl = 1.000000010e+09 lbgidl = -1.901000977e-06 wbgidl = -4.762187958e-06 pbgidl = 8.851480484e-13
++ cgidl = 300.0
++ egidl = 0.1
+* Gate Dielectric Tunneling Current Model Parameters
++ toxref = 4.23e-9
++ dlcig = 0.0
++ aigbacc = 0.43
++ bigbacc = 0.054
++ cigbacc = 0.075
++ nigbacc = 1.0
++ aigbinv = 0.35
++ bigbinv = 0.03
++ cigbinv = 0.006
++ eigbinv = 1.1
++ nigbinv = 3.0
++ aigc = 0.43
++ bigc = 0.054
++ cigc = 0.075
++ aigsd = 0.43
++ bigsd = 0.054
++ cigsd = 0.075
++ nigc = 1.0
++ poxedge = 1.0
++ pigcd = 1.0
++ ntox = 1.0
++ vfbsdoff = 0.0
+* Charge AND Capacitance Model Parameters
++ dlc = 6.265e-9
++ dwc = -3.2175e-8
++ xpart = 0.0
++ cgso = 5.46384e-11
++ cgdo = 5.46384e-11
++ cgbo = 0.0
++ cgdl = 6.920864e-12
++ cgsl = 6.920864e-12
++ clc = 1.0e-7
++ cle = 0.6
++ cf = 1.2e-11
++ ckappas = 0.6
++ vfbcv = -0.1446893
++ acde = 0.552
++ moin = 14.504
++ noff = 4.0
++ voffcv = -0.1375
+* High-Speed/RF Model Parameters
++ xrcrg1 = 12.0
++ xrcrg2 = 1.0
++ rbpb = 50.0
++ rbpd = 50.0
++ rbps = 50.0
++ rbdb = 50.0
++ rbsb = 50.0
++ gbmin = 1.0e-12
+* Flicker AND Thermal Noise Model Parameters
++ ef = 0.88
++ noia = 1.2e+41
++ noib = 2.0e+25
++ noic = 0.0
++ em = 41000000.0
++ ntnoi = 1.0
++ lintnoi = -6.0e-8
++ af = 1.0
++ kf = 0.0
++ tnoia = 1.5
++ tnoib = 3.5
++ rnoia = 0.577
++ rnoib = 0.37
+* Layout-Dependent Parasitics Model Parameters
++ xl = 0.0
++ xw = 0.0
++ dmcg = 0.0
++ dmdg = 0.0
++ dmcgt = 0.0
++ xgw = 0.0
++ xgl = 0.0
++ ngcon = 1.0
+* Asymmetric Source/Drain Junction Diode Model Parameters
++ jss = 2.17e-5
++ jsws = 8.2e-10
++ ijthsfwd = 0.1
++ ijthsrev = 0.1
++ bvs = 12.8
++ xjbvs = 1.0
++ pbs = 0.6587
++ cjs = 0.000672644022
++ mjs = 0.34629
++ pbsws = 0.7418
++ cjsws = 8.60458928e-11
++ mjsws = 0.26859
++ pbswgs = 1.3925
++ cjswgs = 2.299366688e-10
++ mjswgs = 0.70393
+* Temperature Dependence Parameters
++ tnom = 30.0
++ kt1 = 6.243816758e-01 lkt1 = -2.166317965e-07 wkt1 = -5.885999544e-07 pkt1 = 1.094030735e-13
++ kt2 = 1.111362601e+00 lkt2 = -2.144374014e-07 wkt2 = -5.215966208e-07 pkt2 = 9.694916391e-14
++ at = -1.175221209e+04 lat = 2.170835433e-02 wat = 2.186245303e-01 pat = -4.063574145e-8
++ ute = -1.785411394e+00 lute = 2.528540896e-07 wute = -4.483453608e-15 pute = 8.333396195e-22
++ ua1 = -3.768870207e-11 lua1 = 6.152644615e-17 wua1 = -1.177552437e-15 pua1 = 2.188716715e-22
++ ub1 = 4.060735096e-18 lub1 = -7.446251629e-25 wub1 = -2.104576860e-25 pub1 = 3.911777010e-32
++ uc1 = -9.759609062e-10 luc1 = 1.705591272e-16 wuc1 = 4.864263350e-16 puc1 = -9.041206288e-23
++ kt1l = 0.0
++ prt = 0.0
++ tvoff = 0.0
++ njs = 1.2556
++ tpb = 0.0019551
++ tcj = 0.0012407
++ tpbsw = 0.00014242
++ tcjsw = 0.0
++ tpbswg = 0.0
++ tcjswg = 2.0e-12
++ xtis = 2.0
++ tvfbsdoff = 0.0
+* DW AND DL Parameters
++ ll = 0.0
++ wl = 0.0
++ lln = 1.0
++ wln = 1.0
++ lw = 0.0
++ ww = 0.0
++ lwn = 1.0
++ wwn = 1.0
++ lwl = 0.0
++ wwl = 0.0
++ llc = 0.0
++ wlc = 0.0
++ lwc = 0.0
++ wwc = 0.0
++ lwlc = 0.0
++ wwlc = 0.0
+* Stress Parameters
++ saref = 1.04e-6
++ sbref = 1.04e-6
++ kvth0 = 2.65e-8
++ lkvth0 = 0.0
++ wkvth0 = 2.5e-7
++ pkvth0 = 0.0
++ llodvth = 0.0
++ wlodvth = 1.0
++ wlod = 0.0
++ stk2 = 0.0
++ lodk2 = 1.0
++ lodeta0 = 1.0
++ ku0 = 4.5e-8
++ lku0 = 0.0
++ wku0 = 2.5e-7
++ pku0 = 0.0
++ tku0 = 0.0
++ llodku0 = 0.0
++ wlodku0 = 1.0
++ kvsat = 0.4
++ steta0 = 0.0
+* Well Proximity Effect Parameters
+.ends sky130_fd_pr__special_pfet_01v8_hvt

--- a/cells/special_pfet_01v8_hvt/sky130_fd_pr__special_pfet_01v8_hvt__leak.corner.spice
+++ b/cells/special_pfet_01v8_hvt/sky130_fd_pr__special_pfet_01v8_hvt__leak.corner.spice
@@ -1,0 +1,52 @@
+* Copyright 2020 The SkyWater PDK Authors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+
+* SKY130 Spice File.
+* Number of bins: 1
+.param
++ sky130_fd_pr__special_pfet_01v8_hvt__toxe_mult = 0.948
++ sky130_fd_pr__special_pfet_01v8_hvt__rshp_mult = 1.0
++ sky130_fd_pr__special_pfet_01v8_hvt__overlap_mult = 0.91064
++ sky130_fd_pr__special_pfet_01v8_hvt__lint_diff = 1.7325e-8
++ sky130_fd_pr__special_pfet_01v8_hvt__wint_diff = -3.2175e-8
++ sky130_fd_pr__special_pfet_01v8_hvt__dlc_diff = 1.7325e-8
++ sky130_fd_pr__special_pfet_01v8_hvt__dwc_diff = -3.2175e-8
+*
+* sky130_fd_pr__special_pfet_01v8_hvt, Bin 000, W = 0.36, L = 0.15
+* ------------------------------------
++ sky130_fd_pr__special_pfet_01v8_hvt__k2_diff_0 = -0.017396
++ sky130_fd_pr__special_pfet_01v8_hvt__rdsw_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__pdits_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__ua_diff_0 = 8.18463e-10
++ sky130_fd_pr__special_pfet_01v8_hvt__pclm_diff_0 = -0.00010861
++ sky130_fd_pr__special_pfet_01v8_hvt__ub_diff_0 = 1.24897e-19
++ sky130_fd_pr__special_pfet_01v8_hvt__kt1_diff_0 = -0.12438
++ sky130_fd_pr__special_pfet_01v8_hvt__bgidl_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__tvoff_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__cgidl_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__ags_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__a0_diff_0 = 0.00033519
++ sky130_fd_pr__special_pfet_01v8_hvt__voff_diff_0 = -0.14725461
++ sky130_fd_pr__special_pfet_01v8_hvt__pditsd_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__agidl_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__keta_diff_0 = 0.00237543
++ sky130_fd_pr__special_pfet_01v8_hvt__b0_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__b1_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__vsat_diff_0 = -23579.0
++ sky130_fd_pr__special_pfet_01v8_hvt__eta0_diff_0 = -0.01242548
++ sky130_fd_pr__special_pfet_01v8_hvt__u0_diff_0 = 0.0027449
++ sky130_fd_pr__special_pfet_01v8_hvt__nfactor_diff_0 = -1.1455
++ sky130_fd_pr__special_pfet_01v8_hvt__vth0_diff_0 = 0.056312
+*
+.include "sky130_fd_pr__special_pfet_01v8_hvt.pm3.spice"

--- a/cells/special_pfet_01v8_hvt/sky130_fd_pr__special_pfet_01v8_hvt__leak.pm3.spice
+++ b/cells/special_pfet_01v8_hvt/sky130_fd_pr__special_pfet_01v8_hvt__leak.pm3.spice
@@ -1,0 +1,306 @@
+* Copyright 2020 The SkyWater PDK Authors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+
+* SKY130 Spice File.
+.param sky130_fd_pr__special_pfet_01v8_hvt__toxe_slope_spectre = 0.0
+.param sky130_fd_pr__special_pfet_01v8_hvt__vth0_slope_spectre = 0.0
+.param sky130_fd_pr__special_pfet_01v8_hvt__voff_slope_spectre = 0.0
+.param sky130_fd_pr__special_pfet_01v8_hvt__nfactor_slope_spectre = 0.0
+* statistics {
+*   process {
+*   }
+*   mismatch {
+*     vary sky130_fd_pr__special_pfet_01v8_hvt__toxe_slope_spectre dist=gauss std = 1.0
+*     vary sky130_fd_pr__special_pfet_01v8_hvt__vth0_slope_spectre dist=gauss std = 1.0
+*     vary sky130_fd_pr__special_pfet_01v8_hvt__voff_slope_spectre dist=gauss std = 1.0
+*     vary sky130_fd_pr__special_pfet_01v8_hvt__nfactor_slope_spectre dist=gauss std = 1.0
+*   }
+* }
+.subckt  sky130_fd_pr__special_pfet_01v8_hvt d g s b
++ 
+.param  l = 1 w = 1 nf = 1.0 ad = 0 as = 0 pd = 0 ps = 0 nrd = 0 nrs = 0 sa = 0 sb = 0 sd = 0 mult = 1
+msky130_fd_pr__special_pfet_01v8_hvt d g s b sky130_fd_pr__special_pfet_01v8_hvt__model l = {l} w = {w} nf = {nf} ad = {ad} as = {as} pd = {pd} ps = {ps} nrd = {nrd} nrs = {nrs} sa = {sa} sb = {sb} sd = {sd}
+.model sky130_fd_pr__special_pfet_01v8_hvt__model.0 pmos
+* Model Flag Parameters
++ lmin = 1.5e-07 lmax = 1.8e-07 wmin = 3.6e-07 wmax = 4.2e-7
++ level = 54.0
++ version = 4.5
++ binunit = 2.0
++ mobmod = 0.0
++ capmod = 2.0
++ igcmod = 0.0
++ igbmod = 0.0
++ geomod = 0.0
++ diomod = 1.0
++ rdsmod = 0.0
++ rbodymod = 1.0
++ rgatemod = 0.0
++ permod = 1.0
++ acnqsmod = 0.0
++ trnqsmod = 0.0
++ fnoimod = 1.0
++ tnoimod = 1.0
++ tempmod = 0.0
+* Process Parameters
+*(mismatch parameter sky130_fd_pr__special_pfet_01v8_hvt__toxe_slope_spectre)
++ toxe = {4.01004e-09+MC_MM_SWITCH*AGAUSS(0,1.0,1)*(4.23e-9*0.948*(sky130_fd_pr__special_pfet_01v8_hvt__toxe_slope/sqrt(l*w*mult)))}
++ toxm = 4.23e-9
++ dtox = 0.0
++ epsrox = 3.9
++ xj = 1.5e-7
++ ngate = 1.0e+23
++ ndep = 1.7e+17
++ nsd = 1.0e+20
++ rsh = 1.0
++ rshg = 0.1
+* Basic Model Parameters
++ wint = -2.2811e-8
++ lint = -2.935e-9
+*(mismatch parameter sky130_fd_pr__special_pfet_01v8_hvt__vth0_slope_spectre)
++ vth0 = {5.074060142e-01+MC_MM_SWITCH*AGAUSS(0,1.0,1)*(sky130_fd_pr__special_pfet_01v8_hvt__vth0_slope/sqrt(l*w*mult))} lvth0 = -2.917272426e-07 wvth0 = -7.279086425e-07 pvth0 = 1.352963794e-13
++ k1 = -1.747554175e+00 lk1 = 4.831129388e-07 wk1 = 9.190472936e-07 pk1 = -1.708233205e-13
++ k2 = -2.219594058e-01 lk2 = 1.608335076e-08 wk2 = 1.896214072e-07 pk2 = -3.524493096e-14
++ k3 = -13.778
++ k3b = 2.0
++ w0 = 0.0
++ dvt0 = 4.05
++ dvt1 = 0.3
++ dvt2 = 0.03
++ dvt0w = -4.254
++ dvt1w = 1147200.0
++ dvt2w = -0.00896
++ dsub = 6.670698446e+00 ldsub = -1.116811559e-06 wdsub = -2.373756167e-06 pdsub = 4.412100587e-13
++ minv = 0.0
++ voffl = 0.0
++ lpe0 = 0.0
++ lpeb = 0.0
++ vbm = -3.0
++ dvtp0 = 0.0
++ dvtp1 = 0.0
++ phin = 0.0
++ cdsc = 0.0
++ cdscb = 0.0
++ cdscd = 0.0
++ cit = 1.0e-5
+*(mismatch parameter sky130_fd_pr__special_pfet_01v8_hvt__voff_slope_spectre)
++ voff = {-3.576606805e+00+MC_MM_SWITCH*AGAUSS(0,1.0,1)*(sky130_fd_pr__special_pfet_01v8_hvt__voff_slope/sqrt(l*w*mult))} lvoff = 5.804459575e-07 wvoff = 1.152003764e-06 pvoff = -2.141229396e-13
+*(mismatch parameter sky130_fd_pr__special_pfet_01v8_hvt__nfactor_slope_spectre)
++ nfactor = {-1.631964868e+01+MC_MM_SWITCH*AGAUSS(0,1.0,1)*(sky130_fd_pr__special_pfet_01v8_hvt__nfactor_slope/sqrt(l*w*mult))} lnfactor = 3.343537937e-06 wnfactor = 6.761378024e-06 pnfactor = -1.256737333e-12
++ eta0 = 7.745943542e+00 leta0 = -1.348662226e-06 weta0 = -3.378526944e-06 peta0 = 6.279668031e-13
++ etab = 4.457253357e-01 letab = -8.284812984e-08 wetab = -2.060455421e-07 petab = 3.829768491e-14
++ u0 = 3.911196982e-02 lu0 = -6.299965106e-09 wu0 = -1.672647303e-08 pu0 = 3.108949542e-15
++ ua = 1.153628828e-08 lua = -2.442995595e-15 wua = -6.223412863e-15 pua = 1.156745749e-21
++ ub = -2.055422691e-18 lub = 7.390307538e-25 wub = 1.577118196e-24 pub = -2.931389591e-31
++ uc = -3.828960618e-10 luc = 7.121685309e-17 wuc = 2.253841722e-16 puc = -4.189215609e-23
++ ud = 0.0
++ up = 0.0
++ lp = 1.0
++ eu = 1.67
++ vtl = 0.0
++ xn = 3.0
++ vsat = 1.714324205e+06 lvsat = -3.030419284e-01 wvsat = -6.951121410e-01 pvsat = 1.292004937e-7
++ a0 = 1.808836105e+00 la0 = -1.194253977e-07 wa0 = 9.113817138e-08 pa0 = -1.693985192e-14
++ ags = 1.249999985e+00 lags = 2.731505688e-15 wags = 6.842682865e-15 pags = -1.271849293e-21
++ a1 = 0.0
++ a2 = -8.632484378e+00 la2 = 1.688625294e-06 wa2 = 3.790768904e-06 pa2 = -7.045902162e-13
++ b0 = 0.0
++ b1 = 0.0
++ keta = -1.472423496e+00 lketa = 2.684343382e-07 wketa = 6.458863228e-07 pketa = -1.200508908e-13
++ dwg = -5.722e-9
++ dwb = -1.7864e-8
++ pclm = 1.940062338e+00 lpclm = -2.069482190e-07 wpclm = -2.953032308e-08 ppclm = 5.488801151e-15
++ pdiblc1 = 9.440897930e-02 lpdiblc1 = 1.735265047e-08 wpdiblc1 = 1.027953514e-07 ppdiblc1 = -1.910657197e-14
++ pdiblc2 = 6.230151542e-02 lpdiblc2 = -1.033569296e-08 wpdiblc2 = -1.866184791e-08 ppdiblc2 = 3.468677671e-15
++ pdiblcb = -9.647124730e+00 lpdiblcb = 1.751290324e-06 wpdiblcb = 5.067553259e-06 ppdiblcb = -9.419061243e-13
++ drout = 9.882548598e-01 ldrout = 1.830715458e-09 wdrout = 6.956739185e-15 pdrout = -1.293049223e-21
++ pscbe1 = 1.285433399e+09 lpscbe1 = -9.023335140e+01 wpscbe1 = -2.261181578e+02 ppscbe1 = 4.202858199e-5
++ pscbe2 = 1.576995002e-08 lpscbe2 = -1.199320176e-15 wpscbe2 = -3.377489220e-15 ppscbe2 = 6.277739214e-22
++ pvag = 0.0
++ delta = 0.01
++ fprout = 0.0
++ pdits = 0.0
++ pditsl = 0.0
++ pditsd = 0.0
++ lambda = 0.0
++ lc = 5.0e-9
+* Parameters FOR Asymmetric AND Bias-Dependent RDS Model
++ rdsw = 531.92
++ rsw = 0.0
++ rdw = 0.0
++ rdswmin = 0.0
++ rdwmin = 0.0
++ rswmin = 0.0
++ prwb = -0.32348
++ prwg = 0.02
++ wr = 1.0
+* Impact Ionization Current Model Parameters
++ alpha0 = 1.0e-10
++ alpha1 = 1.0e-10
++ beta0 = 2.257026038e+01 lbeta0 = -2.506465477e-06 wbeta0 = -4.577582627e-06 pbeta0 = 8.508352829e-13
+* Gidl Induced Drain Leakage Model Parameters
++ agidl = 0.0
++ bgidl = 1.000000010e+09 lbgidl = -1.901000977e-06 wbgidl = -4.762187958e-06 pbgidl = 8.851480484e-13
++ cgidl = 300.0
++ egidl = 0.1
+* Gate Dielectric Tunneling Current Model Parameters
++ toxref = 4.23e-9
++ dlcig = 0.0
++ aigbacc = 0.43
++ bigbacc = 0.054
++ cigbacc = 0.075
++ nigbacc = 1.0
++ aigbinv = 0.35
++ bigbinv = 0.03
++ cigbinv = 0.006
++ eigbinv = 1.1
++ nigbinv = 3.0
++ aigc = 0.43
++ bigc = 0.054
++ cigc = 0.075
++ aigsd = 0.43
++ bigsd = 0.054
++ cigsd = 0.075
++ nigc = 1.0
++ poxedge = 1.0
++ pigcd = 1.0
++ ntox = 1.0
++ vfbsdoff = 0.0
+* Charge AND Capacitance Model Parameters
++ dlc = 6.265e-9
++ dwc = -3.2175e-8
++ xpart = 0.0
++ cgso = 5.46384e-11
++ cgdo = 5.46384e-11
++ cgbo = 0.0
++ cgdl = 6.920864e-12
++ cgsl = 6.920864e-12
++ clc = 1.0e-7
++ cle = 0.6
++ cf = 1.2e-11
++ ckappas = 0.6
++ vfbcv = -0.1446893
++ acde = 0.552
++ moin = 14.504
++ noff = 4.0
++ voffcv = -0.1375
+* High-Speed/RF Model Parameters
++ xrcrg1 = 12.0
++ xrcrg2 = 1.0
++ rbpb = 50.0
++ rbpd = 50.0
++ rbps = 50.0
++ rbdb = 50.0
++ rbsb = 50.0
++ gbmin = 1.0e-12
+* Flicker AND Thermal Noise Model Parameters
++ ef = 0.88
++ noia = 1.2e+41
++ noib = 2.0e+25
++ noic = 0.0
++ em = 41000000.0
++ ntnoi = 1.0
++ lintnoi = -6.0e-8
++ af = 1.0
++ kf = 0.0
++ tnoia = 1.5
++ tnoib = 3.5
++ rnoia = 0.577
++ rnoib = 0.37
+* Layout-Dependent Parasitics Model Parameters
++ xl = 0.0
++ xw = 0.0
++ dmcg = 0.0
++ dmdg = 0.0
++ dmcgt = 0.0
++ xgw = 0.0
++ xgl = 0.0
++ ngcon = 1.0
+* Asymmetric Source/Drain Junction Diode Model Parameters
++ jss = 2.17e-5
++ jsws = 8.2e-10
++ ijthsfwd = 0.1
++ ijthsrev = 0.1
++ bvs = 12.8
++ xjbvs = 1.0
++ pbs = 0.6587
++ cjs = 0.000672644022
++ mjs = 0.34629
++ pbsws = 0.7418
++ cjsws = 8.60458928e-11
++ mjsws = 0.26859
++ pbswgs = 1.3925
++ cjswgs = 2.299366688e-10
++ mjswgs = 0.70393
+* Temperature Dependence Parameters
++ tnom = 30.0
++ kt1 = 3.606711407e+00 lkt1 = -7.755437659e-07 wkt1 = -1.598181263e-06 pkt1 = 2.970539513e-13
++ kt2 = 1.111362601e+00 lkt2 = -2.144374014e-07 wkt2 = -5.215966208e-07 pkt2 = 9.694916391e-14
++ at = -1.175221209e+04 lat = 2.170835433e-02 wat = 2.186245303e-01 pat = -4.063574145e-8
++ ute = -1.785411394e+00 lute = 2.528540896e-07 wute = -4.483453608e-15 pute = 8.333396195e-22
++ ua1 = -3.768870207e-11 lua1 = 6.152644615e-17 wua1 = -1.177552437e-15 pua1 = 2.188716715e-22
++ ub1 = 4.060735096e-18 lub1 = -7.446251629e-25 wub1 = -2.104576860e-25 pub1 = 3.911777010e-32
++ uc1 = -9.759609062e-10 luc1 = 1.705591272e-16 wuc1 = 4.864263350e-16 puc1 = -9.041206288e-23
++ kt1l = 0.0
++ prt = 0.0
++ tvoff = 0.0
++ njs = 1.2556
++ tpb = 0.0019551
++ tcj = 0.0012407
++ tpbsw = 0.00014242
++ tcjsw = 0.0
++ tpbswg = 0.0
++ tcjswg = 2.0e-12
++ xtis = 2.0
++ tvfbsdoff = 0.0
+* DW AND DL Parameters
++ ll = 0.0
++ wl = 0.0
++ lln = 1.0
++ wln = 1.0
++ lw = 0.0
++ ww = 0.0
++ lwn = 1.0
++ wwn = 1.0
++ lwl = 0.0
++ wwl = 0.0
++ llc = 0.0
++ wlc = 0.0
++ lwc = 0.0
++ wwc = 0.0
++ lwlc = 0.0
++ wwlc = 0.0
+* Stress Parameters
++ saref = 1.04e-6
++ sbref = 1.04e-6
++ kvth0 = 2.65e-8
++ lkvth0 = 0.0
++ wkvth0 = 2.5e-7
++ pkvth0 = 0.0
++ llodvth = 0.0
++ wlodvth = 1.0
++ wlod = 0.0
++ stk2 = 0.0
++ lodk2 = 1.0
++ lodeta0 = 1.0
++ ku0 = 4.5e-8
++ lku0 = 0.0
++ wku0 = 2.5e-7
++ pku0 = 0.0
++ tku0 = 0.0
++ llodku0 = 0.0
++ wlodku0 = 1.0
++ kvsat = 0.4
++ steta0 = 0.0
+* Well Proximity Effect Parameters
+.ends sky130_fd_pr__special_pfet_01v8_hvt

--- a/cells/special_pfet_01v8_hvt/sky130_fd_pr__special_pfet_01v8_hvt__mismatch.corner.spice
+++ b/cells/special_pfet_01v8_hvt/sky130_fd_pr__special_pfet_01v8_hvt__mismatch.corner.spice
@@ -1,0 +1,23 @@
+* Copyright 2020 The SkyWater PDK Authors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+
+* SKY130 Spice File.
+.param sky130_fd_pr__special_pfet_01v8_hvt__toxe_slope= 5.00e-3
+.param sky130_fd_pr__special_pfet_01v8_hvt__vth0_slope= 5.50e-3
+.param sky130_fd_pr__special_pfet_01v8_hvt__nfactor_slope=0.0
+.param sky130_fd_pr__special_pfet_01v8_hvt__nfactor_slope1=0.0
+.param sky130_fd_pr__special_pfet_01v8_hvt__voff_slope=0.01
+.param sky130_fd_pr__special_pfet_01v8_hvt__voff_slope1=0.00
+.param sky130_fd_pr__special_pfet_01v8_hvt__lint_slope=0.0
+.param sky130_fd_pr__special_pfet_01v8_hvt__wint_slope=0.0

--- a/cells/special_pfet_01v8_hvt/sky130_fd_pr__special_pfet_01v8_hvt__sf.corner.spice
+++ b/cells/special_pfet_01v8_hvt/sky130_fd_pr__special_pfet_01v8_hvt__sf.corner.spice
@@ -1,0 +1,52 @@
+* Copyright 2020 The SkyWater PDK Authors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+
+* SKY130 Spice File.
+* Number of bins: 1
+.param
++ sky130_fd_pr__special_pfet_01v8_hvt__toxe_mult = 1.052
++ sky130_fd_pr__special_pfet_01v8_hvt__rshp_mult = 1.0
++ sky130_fd_pr__special_pfet_01v8_hvt__overlap_mult = 1.2
++ sky130_fd_pr__special_pfet_01v8_hvt__lint_diff = -1.7325e-8
++ sky130_fd_pr__special_pfet_01v8_hvt__wint_diff = 3.2175e-8
++ sky130_fd_pr__special_pfet_01v8_hvt__dlc_diff = -1.7325e-8
++ sky130_fd_pr__special_pfet_01v8_hvt__dwc_diff = 3.2175e-8
+*
+* sky130_fd_pr__special_pfet_01v8_hvt, Bin 000, W = 0.36, L = 0.15
+* ------------------------------------
++ sky130_fd_pr__special_pfet_01v8_hvt__k2_diff_0 = -0.028469
++ sky130_fd_pr__special_pfet_01v8_hvt__rdsw_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__pdits_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__ua_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__pclm_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__ub_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__kt1_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__bgidl_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__tvoff_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__cgidl_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__ags_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__a0_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__voff_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__pditsd_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__agidl_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__keta_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__b0_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__b1_diff_0 = 8.74443e-30
++ sky130_fd_pr__special_pfet_01v8_hvt__vsat_diff_0 = 50000.0
++ sky130_fd_pr__special_pfet_01v8_hvt__eta0_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__u0_diff_0 = 0.00064265
++ sky130_fd_pr__special_pfet_01v8_hvt__nfactor_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__vth0_diff_0 = -0.07169
+*
+.include "sky130_fd_pr__special_pfet_01v8_hvt__sf.pm3.spice"

--- a/cells/special_pfet_01v8_hvt/sky130_fd_pr__special_pfet_01v8_hvt__sf.pm3.spice
+++ b/cells/special_pfet_01v8_hvt/sky130_fd_pr__special_pfet_01v8_hvt__sf.pm3.spice
@@ -1,0 +1,306 @@
+* Copyright 2020 The SkyWater PDK Authors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+
+* SKY130 Spice File.
+.param sky130_fd_pr__special_pfet_01v8_hvt__toxe_slope_spectre = 0.0
+.param sky130_fd_pr__special_pfet_01v8_hvt__vth0_slope_spectre = 0.0
+.param sky130_fd_pr__special_pfet_01v8_hvt__voff_slope_spectre = 0.0
+.param sky130_fd_pr__special_pfet_01v8_hvt__nfactor_slope_spectre = 0.0
+* statistics {
+*   process {
+*   }
+*   mismatch {
+*     vary sky130_fd_pr__special_pfet_01v8_hvt__toxe_slope_spectre dist=gauss std = 1.0
+*     vary sky130_fd_pr__special_pfet_01v8_hvt__vth0_slope_spectre dist=gauss std = 1.0
+*     vary sky130_fd_pr__special_pfet_01v8_hvt__voff_slope_spectre dist=gauss std = 1.0
+*     vary sky130_fd_pr__special_pfet_01v8_hvt__nfactor_slope_spectre dist=gauss std = 1.0
+*   }
+* }
+.subckt  sky130_fd_pr__special_pfet_01v8_hvt d g s b
++ 
+.param  l = 1 w = 1 nf = 1.0 ad = 0 as = 0 pd = 0 ps = 0 nrd = 0 nrs = 0 sa = 0 sb = 0 sd = 0 mult = 1
+msky130_fd_pr__special_pfet_01v8_hvt d g s b sky130_fd_pr__special_pfet_01v8_hvt__model l = {l} w = {w} nf = {nf} ad = {ad} as = {as} pd = {pd} ps = {ps} nrd = {nrd} nrs = {nrs} sa = {sa} sb = {sb} sd = {sd}
+.model sky130_fd_pr__special_pfet_01v8_hvt__model.0 pmos
+* Model Flag Parameters
++ lmin = 1.5e-07 lmax = 1.8e-07 wmin = 3.6e-07 wmax = 4.2e-7
++ level = 54.0
++ version = 4.5
++ binunit = 2.0
++ mobmod = 0.0
++ capmod = 2.0
++ igcmod = 0.0
++ igbmod = 0.0
++ geomod = 0.0
++ diomod = 1.0
++ rdsmod = 0.0
++ rbodymod = 1.0
++ rgatemod = 0.0
++ permod = 1.0
++ acnqsmod = 0.0
++ trnqsmod = 0.0
++ fnoimod = 1.0
++ tnoimod = 1.0
++ tempmod = 0.0
+* Process Parameters
+*(mismatch parameter sky130_fd_pr__special_pfet_01v8_hvt__toxe_slope_spectre)
++ toxe = {4.44996e-09+MC_MM_SWITCH*AGAUSS(0,1.0,1)*(4.23e-9*1.052*(sky130_fd_pr__special_pfet_01v8_hvt__toxe_slope/sqrt(l*w*mult)))}
++ toxm = 4.23e-9
++ dtox = 0.0
++ epsrox = 3.9
++ xj = 1.5e-7
++ ngate = 1.0e+23
++ ndep = 1.7e+17
++ nsd = 1.0e+20
++ rsh = 1.0
++ rshg = 0.1
+* Basic Model Parameters
++ wint = 4.1539e-8
++ lint = -3.7585e-8
+*(mismatch parameter sky130_fd_pr__special_pfet_01v8_hvt__vth0_slope_spectre)
++ vth0 = {-4.263958532e+00+MC_MM_SWITCH*AGAUSS(0,1.0,1)*(sky130_fd_pr__special_pfet_01v8_hvt__vth0_slope/sqrt(l*w*mult))} lvth0 = 8.210210934e-07 wvth0 = 1.099679894e-06 pvth0 = -2.806053186e-13
++ k1 = -1.998450892e+00 lk1 = 7.272586779e-07 wk1 = 6.558698822e-07 pk1 = -1.673583179e-13
++ k2 = -1.169590294e+00 lk2 = 2.657224262e-07 wk2 = 4.787377281e-07 pk2 = -1.221595061e-13
++ k3 = -13.778
++ k3b = 2.0
++ w0 = 0.0
++ dvt0 = 4.05
++ dvt1 = 0.3
++ dvt2 = 0.03
++ dvt0w = -4.254
++ dvt1w = 1147200.0
++ dvt2w = -0.00896
++ dsub = 7.005387830e+00 ldsub = -1.618607649e-06 wdsub = -1.694009861e-06 pdsub = 4.322604961e-13
++ minv = 0.0
++ voffl = 0.0
++ lpe0 = 0.0
++ lpeb = 0.0
++ vbm = -3.0
++ dvtp0 = 0.0
++ dvtp1 = 0.0
++ phin = 0.0
++ cdsc = 0.0
++ cdscb = 0.0
++ cdscd = 0.0
++ cit = 1.0e-5
+*(mismatch parameter sky130_fd_pr__special_pfet_01v8_hvt__voff_slope_spectre)
++ voff = {-5.439247112e+00+MC_MM_SWITCH*AGAUSS(0,1.0,1)*(sky130_fd_pr__special_pfet_01v8_hvt__voff_slope/sqrt(l*w*mult))} lvoff = 1.364949021e-06 wvoff = 1.818011638e-06 pvoff = -4.639020297e-13
+*(mismatch parameter sky130_fd_pr__special_pfet_01v8_hvt__nfactor_slope_spectre)
++ nfactor = {6.788592669e+01+MC_MM_SWITCH*AGAUSS(0,1.0,1)*(sky130_fd_pr__special_pfet_01v8_hvt__nfactor_slope/sqrt(l*w*mult))} lnfactor = -1.659000827e-05 wnfactor = -1.841569662e-05 pnfactor = 4.699133307e-12
++ eta0 = 8.076559862e+00 leta0 = -1.935862480e-06 weta0 = -2.556078922e-06 peta0 = 6.522346585e-13
++ etab = 4.410669612e-01 letab = -1.125486513e-07 wetab = -1.470425585e-07 petab = 3.752084965e-14
++ u0 = 3.849175305e-02 lu0 = -9.390932978e-09 wu0 = -1.609285492e-08 pu0 = 4.106413791e-15
++ ua = -2.530694941e-08 lua = 5.814851319e-15 wua = 5.237302848e-15 pua = -1.336402568e-21
++ ub = 4.347944645e-17 lub = -1.059092719e-23 wub = -1.115827407e-23 pub = 2.847256795e-30
++ uc = -3.313787141e-10 luc = 8.462375079e-17 wuc = 1.608433990e-16 puc = -4.104241011e-23
++ ud = 0.0
++ up = 0.0
++ lp = 1.0
++ eu = 1.67
++ vtl = 0.0
++ xn = 3.0
++ vsat = 3.128553123e+06 lvsat = -7.470441441e-01 wvsat = -7.538130629e-01 pvsat = 1.923504793e-7
++ a0 = 2.172606755e+00 la0 = -2.567754672e-07 wa0 = 6.895209465e-08 pa0 = -1.759450599e-14
++ ags = 1.249999986e+00 lags = 3.698335860e-15 wags = 4.883215610e-15 pags = -1.246050818e-21
++ a1 = 0.0
++ a2 = -8.940045776e+00 la2 = 2.396694872e-06 wa2 = 2.705248328e-06 pa2 = -6.902982160e-13
++ b0 = 0.0
++ b1 = 3.029193301e-28 lb1 = -7.729592547e-35 wb1 = -1.020601866e-34 pb1 = 2.604269780e-41
++ keta = -1.560996587e+00 lketa = 3.911189234e-07 wketa = 4.886557132e-07 pketa = -1.246902783e-13
++ dwg = -5.722e-9
++ dwb = -1.7864e-8
++ pclm = 2.409775491e+00 lpclm = -4.039637534e-07 wpclm = -2.234168728e-08 ppclm = 5.700928344e-15
++ pdiblc1 = 1.540931479e-01 lpdiblc1 = 8.592824768e-09 wpdiblc1 = 7.335898328e-08 ppdiblc1 = -1.871901176e-14
++ pdiblc2 = 6.865378525e-02 lpdiblc2 = -1.581017416e-08 wpdiblc2 = -1.331786087e-08 ppdiblc2 = 3.398318559e-15
++ pdiblcb = -8.847714611e+00 lpdiblcb = 2.200258087e-06 wpdiblcb = 3.616414065e-06 ppdiblcb = -9.228003771e-13
++ drout = 9.838757930e-01 ldrout = 3.630688140e-09 wdrout = 4.964615385e-15 pdrout = -1.266820870e-21
++ pscbe1 = 1.278681003e+09 lpscbe1 = -1.221530566e+02 wpscbe1 = -1.613672012e+02 ppscbe1 = 4.117606873e-5
++ pscbe2 = 1.531392544e-08 lpscbe2 = -1.530112395e-15 wpscbe2 = -2.410314978e-15 ppscbe2 = 6.150400730e-22
++ pvag = 0.0
++ delta = 0.01
++ fprout = 0.0
++ pdits = 0.0
++ pditsl = 0.0
++ pditsd = 0.0
++ lambda = 0.0
++ lc = 5.0e-9
+* Parameters FOR Asymmetric AND Bias-Dependent RDS Model
++ rdsw = 531.92
++ rsw = 0.0
++ rdw = 0.0
++ rdswmin = 0.0
++ rdwmin = 0.0
++ rswmin = 0.0
++ prwb = -0.32348
++ prwg = 0.02
++ wr = 1.0
+* Impact Ionization Current Model Parameters
++ alpha0 = 1.0e-10
++ alpha1 = 1.0e-10
++ beta0 = 2.405955718e+01 lbeta0 = -3.821003023e-06 wbeta0 = -3.266750906e-06 pbeta0 = 8.335768286e-13
+* Gidl Induced Drain Leakage Model Parameters
++ agidl = -1.495839366e-07 lagidl = 3.891603038e-14 wagidl = 4.831564640e-14 pagidl = -1.232870349e-20
++ bgidl = 1.000000010e+09 lbgidl = -2.573869705e-06 wbgidl = -3.398494720e-06 pbgidl = 8.671936989e-13
++ cgidl = 300.0
++ egidl = 0.1
+* Gate Dielectric Tunneling Current Model Parameters
++ toxref = 4.23e-9
++ dlcig = 0.0
++ aigbacc = 0.43
++ bigbacc = 0.054
++ cigbacc = 0.075
++ nigbacc = 1.0
++ aigbinv = 0.35
++ bigbinv = 0.03
++ cigbinv = 0.006
++ eigbinv = 1.1
++ nigbinv = 3.0
++ aigc = 0.43
++ bigc = 0.054
++ cigc = 0.075
++ aigsd = 0.43
++ bigsd = 0.054
++ cigsd = 0.075
++ nigc = 1.0
++ poxedge = 1.0
++ pigcd = 1.0
++ ntox = 1.0
++ vfbsdoff = 0.0
+* Charge AND Capacitance Model Parameters
++ dlc = -2.8385e-8
++ dwc = 3.2175e-8
++ xpart = 0.0
++ cgso = 7.2e-11
++ cgdo = 7.2e-11
++ cgbo = 0.0
++ cgdl = 9.12e-12
++ cgsl = 9.12e-12
++ clc = 1.0e-7
++ cle = 0.6
++ cf = 1.2e-11
++ ckappas = 0.6
++ vfbcv = -0.1446893
++ acde = 0.552
++ moin = 14.504
++ noff = 4.0
++ voffcv = -0.1375
+* High-Speed/RF Model Parameters
++ xrcrg1 = 12.0
++ xrcrg2 = 1.0
++ rbpb = 50.0
++ rbpd = 50.0
++ rbps = 50.0
++ rbdb = 50.0
++ rbsb = 50.0
++ gbmin = 1.0e-12
+* Flicker AND Thermal Noise Model Parameters
++ ef = 0.88
++ noia = 1.2e+41
++ noib = 2.0e+25
++ noic = 0.0
++ em = 41000000.0
++ ntnoi = 1.0
++ lintnoi = -6.0e-8
++ af = 1.0
++ kf = 0.0
++ tnoia = 1.5
++ tnoib = 3.5
++ rnoia = 0.577
++ rnoib = 0.37
+* Layout-Dependent Parasitics Model Parameters
++ xl = 0.0
++ xw = 0.0
++ dmcg = 0.0
++ dmdg = 0.0
++ dmcgt = 0.0
++ xgw = 0.0
++ xgl = 0.0
++ ngcon = 1.0
+* Asymmetric Source/Drain Junction Diode Model Parameters
++ jss = 2.17e-5
++ jsws = 8.2e-10
++ ijthsfwd = 0.1
++ ijthsrev = 0.1
++ bvs = 12.8
++ xjbvs = 1.0
++ pbs = 0.6587
++ cjs = 0.000813867531
++ mjs = 0.34629
++ pbsws = 0.7418
++ cjsws = 1.041095405e-10
++ mjsws = 0.26859
++ pbswgs = 1.3925
++ cjswgs = 2.78207363e-10
++ mjswgs = 0.70393
+* Temperature Dependence Parameters
++ tnom = 30.0
++ kt1 = 5.631474861e-01 lkt1 = -2.817759344e-07 wkt1 = -4.200490937e-07 pkt1 = 1.071839272e-13
++ kt2 = 1.110837488e+00 lkt2 = -2.942545135e-07 wkt2 = -3.722327639e-07 pkt2 = 9.498263437e-14
++ at = 1.515353355e+05 lat = -1.186395958e-02 wat = 1.560194409e-01 pat = -3.981148075e-8
++ ute = -2.390238694e+00 lute = 5.014623024e-07 wute = -3.199576604e-15 pute = 8.164360299e-22
++ ua1 = -1.344042497e-09 lua1 = 4.178083401e-16 wua1 = -8.403497662e-16 pua1 = 2.144320498e-22
++ ub1 = 5.634704891e-18 lub1 = -1.423881999e-24 wub1 = -1.501912456e-25 pub1 = 3.832430013e-32
++ uc1 = -9.051005315e-10 luc1 = 2.160691607e-16 wuc1 = 3.471338040e-16 puc1 = -8.857813276e-23
++ kt1l = 0.0
++ prt = 0.0
++ tvoff = 0.0
++ njs = 1.2556
++ tpb = 0.0019551
++ tcj = 0.0012407
++ tpbsw = 0.00014242
++ tcjsw = 0.0
++ tpbswg = 0.0
++ tcjswg = 2.0e-12
++ xtis = 2.0
++ tvfbsdoff = 0.0
+* DW AND DL Parameters
++ ll = 0.0
++ wl = 0.0
++ lln = 1.0
++ wln = 1.0
++ lw = 0.0
++ ww = 0.0
++ lwn = 1.0
++ wwn = 1.0
++ lwl = 0.0
++ wwl = 0.0
++ llc = 0.0
++ wlc = 0.0
++ lwc = 0.0
++ wwc = 0.0
++ lwlc = 0.0
++ wwlc = 0.0
+* Stress Parameters
++ saref = 1.04e-6
++ sbref = 1.04e-6
++ kvth0 = 2.65e-8
++ lkvth0 = 0.0
++ wkvth0 = 2.5e-7
++ pkvth0 = 0.0
++ llodvth = 0.0
++ wlodvth = 1.0
++ wlod = 0.0
++ stk2 = 0.0
++ lodk2 = 1.0
++ lodeta0 = 1.0
++ ku0 = 4.5e-8
++ lku0 = 0.0
++ wku0 = 2.5e-7
++ pku0 = 0.0
++ tku0 = 0.0
++ llodku0 = 0.0
++ wlodku0 = 1.0
++ kvsat = 0.4
++ steta0 = 0.0
+* Well Proximity Effect Parameters
+.ends sky130_fd_pr__special_pfet_01v8_hvt

--- a/cells/special_pfet_01v8_hvt/sky130_fd_pr__special_pfet_01v8_hvt__ss.corner.spice
+++ b/cells/special_pfet_01v8_hvt/sky130_fd_pr__special_pfet_01v8_hvt__ss.corner.spice
@@ -1,0 +1,52 @@
+* Copyright 2020 The SkyWater PDK Authors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+
+* SKY130 Spice File.
+* Number of bins: 1
+.param
++ sky130_fd_pr__special_pfet_01v8_hvt__toxe_mult = 1.0365
++ sky130_fd_pr__special_pfet_01v8_hvt__rshp_mult = 1.0
++ sky130_fd_pr__special_pfet_01v8_hvt__overlap_mult = 1.1614
++ sky130_fd_pr__special_pfet_01v8_hvt__lint_diff = -1.21275e-8
++ sky130_fd_pr__special_pfet_01v8_hvt__wint_diff = 2.252e-8
++ sky130_fd_pr__special_pfet_01v8_hvt__dlc_diff = -1.21275e-8
++ sky130_fd_pr__special_pfet_01v8_hvt__dwc_diff = 2.252e-8
+*
+* sky130_fd_pr__special_pfet_01v8_hvt, Bin 000, W = 0.36, L = 0.15
+* ------------------------------------
++ sky130_fd_pr__special_pfet_01v8_hvt__k2_diff_0 = -0.026
++ sky130_fd_pr__special_pfet_01v8_hvt__rdsw_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__pdits_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__ua_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__pclm_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__ub_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__kt1_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__bgidl_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__tvoff_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__cgidl_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__ags_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__a0_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__voff_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__pditsd_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__agidl_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__keta_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__b0_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__b1_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__vsat_diff_0 = -7744.3
++ sky130_fd_pr__special_pfet_01v8_hvt__eta0_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__u0_diff_0 = -2.1326e-5
++ sky130_fd_pr__special_pfet_01v8_hvt__nfactor_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__vth0_diff_0 = -0.040606
+*
+.include "sky130_fd_pr__special_pfet_01v8_hvt__ss.pm3.spice"

--- a/cells/special_pfet_01v8_hvt/sky130_fd_pr__special_pfet_01v8_hvt__ss.pm3.spice
+++ b/cells/special_pfet_01v8_hvt/sky130_fd_pr__special_pfet_01v8_hvt__ss.pm3.spice
@@ -1,0 +1,306 @@
+* Copyright 2020 The SkyWater PDK Authors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+
+* SKY130 Spice File.
+.param sky130_fd_pr__special_pfet_01v8_hvt__toxe_slope_spectre = 0.0
+.param sky130_fd_pr__special_pfet_01v8_hvt__vth0_slope_spectre = 0.0
+.param sky130_fd_pr__special_pfet_01v8_hvt__voff_slope_spectre = 0.0
+.param sky130_fd_pr__special_pfet_01v8_hvt__nfactor_slope_spectre = 0.0
+* statistics {
+*   process {
+*   }
+*   mismatch {
+*     vary sky130_fd_pr__special_pfet_01v8_hvt__toxe_slope_spectre dist=gauss std = 1.0
+*     vary sky130_fd_pr__special_pfet_01v8_hvt__vth0_slope_spectre dist=gauss std = 1.0
+*     vary sky130_fd_pr__special_pfet_01v8_hvt__voff_slope_spectre dist=gauss std = 1.0
+*     vary sky130_fd_pr__special_pfet_01v8_hvt__nfactor_slope_spectre dist=gauss std = 1.0
+*   }
+* }
+.subckt  sky130_fd_pr__special_pfet_01v8_hvt d g s b
++ 
+.param  l = 1 w = 1 nf = 1.0 ad = 0 as = 0 pd = 0 ps = 0 nrd = 0 nrs = 0 sa = 0 sb = 0 sd = 0 mult = 1
+msky130_fd_pr__special_pfet_01v8_hvt d g s b sky130_fd_pr__special_pfet_01v8_hvt__model l = {l} w = {w} nf = {nf} ad = {ad} as = {as} pd = {pd} ps = {ps} nrd = {nrd} nrs = {nrs} sa = {sa} sb = {sb} sd = {sd}
+.model sky130_fd_pr__special_pfet_01v8_hvt__model.0 pmos
+* Model Flag Parameters
++ lmin = 1.5e-07 lmax = 1.8e-07 wmin = 3.6e-07 wmax = 4.2e-7
++ level = 54.0
++ version = 4.5
++ binunit = 2.0
++ mobmod = 0.0
++ capmod = 2.0
++ igcmod = 0.0
++ igbmod = 0.0
++ geomod = 0.0
++ diomod = 1.0
++ rdsmod = 0.0
++ rbodymod = 1.0
++ rgatemod = 0.0
++ permod = 1.0
++ acnqsmod = 0.0
++ trnqsmod = 0.0
++ fnoimod = 1.0
++ tnoimod = 1.0
++ tempmod = 0.0
+* Process Parameters
+*(mismatch parameter sky130_fd_pr__special_pfet_01v8_hvt__toxe_slope_spectre)
++ toxe = {4.384395e-09+MC_MM_SWITCH*AGAUSS(0,1.0,1)*(4.23e-9*1.0365*(sky130_fd_pr__special_pfet_01v8_hvt__toxe_slope/sqrt(l*w*mult)))}
++ toxm = 4.23e-9
++ dtox = 0.0
++ epsrox = 3.9
++ xj = 1.5e-7
++ ngate = 1.0e+23
++ ndep = 1.7e+17
++ nsd = 1.0e+20
++ rsh = 1.0
++ rshg = 0.1
+* Basic Model Parameters
++ wint = 3.1884e-8
++ lint = -3.23875e-8
+*(mismatch parameter sky130_fd_pr__special_pfet_01v8_hvt__vth0_slope_spectre)
++ vth0 = {-1.590239467e+00+MC_MM_SWITCH*AGAUSS(0,1.0,1)*(sky130_fd_pr__special_pfet_01v8_hvt__vth0_slope/sqrt(l*w*mult))} lvth0 = 1.330962758e-07 wvth0 = 3.079070308e-07 pvth0 = -7.536794346e-14
++ k1 = -1.996351050e+00 lk1 = 6.971179541e-07 wk1 = 7.075692627e-07 pk1 = -1.731952663e-13
++ k2 = -2.704070119e-01 lk2 = 3.527014180e-08 wk2 = 2.357592592e-07 pk2 = -5.770797268e-14
++ k3 = -13.778
++ k3b = 2.0
++ w0 = 0.0
++ dvt0 = 4.05
++ dvt1 = 0.3
++ dvt2 = 0.03
++ dvt0w = -4.254
++ dvt1w = 1147200.0
++ dvt2w = -0.00896
++ dsub = 7.046964934e+00 ldsub = -1.562846578e-06 wdsub = -1.827541316e-06 pdsub = 4.473364257e-13
++ minv = 0.0
++ voffl = 0.0
++ lpe0 = 0.0
++ lpeb = 0.0
++ vbm = -3.0
++ dvtp0 = 0.0
++ dvtp1 = 0.0
++ phin = 0.0
++ cdsc = 0.0
++ cdscb = 0.0
++ cdscd = 0.0
++ cit = 1.0e-5
+*(mismatch parameter sky130_fd_pr__special_pfet_01v8_hvt__voff_slope_spectre)
++ voff = {-2.108998367e+00+MC_MM_SWITCH*AGAUSS(0,1.0,1)*(sky130_fd_pr__special_pfet_01v8_hvt__voff_slope/sqrt(l*w*mult))} lvoff = 4.799823320e-07 wvoff = 8.014086043e-07 pvoff = -1.961647911e-13
+*(mismatch parameter sky130_fd_pr__special_pfet_01v8_hvt__nfactor_slope_spectre)
++ nfactor = {4.301268408e+01+MC_MM_SWITCH*AGAUSS(0,1.0,1)*(sky130_fd_pr__special_pfet_01v8_hvt__nfactor_slope/sqrt(l*w*mult))} lnfactor = -1.009054626e-05 wnfactor = -1.492524072e-05 pnfactor = 3.653325797e-12
++ eta0 = 8.230920372e+00 leta0 = -1.894783784e-06 weta0 = -2.757563546e-06 peta0 = 6.749826169e-13
++ etab = 4.497324014e-01 letab = -1.100847784e-07 wetab = -1.586332861e-07 petab = 3.882946261e-14
++ u0 = 2.685845234e-02 lu0 = -6.211325302e-09 wu0 = -1.256791649e-08 pu0 = 3.076311759e-15
++ ua = -1.029761455e-08 lua = 1.852707249e-15 wua = 7.021962449e-16 pua = -1.718800859e-22
++ ub = 2.045204657e-17 lub = -4.443703525e-24 wub = -4.348982753e-24 pub = 1.064522253e-30
++ uc = -3.478207221e-10 luc = 8.520097923e-17 wuc = 1.735219870e-16 puc = -4.247384438e-23
++ ud = 0.0
++ up = 0.0
++ lp = 1.0
++ eu = 1.67
++ vtl = 0.0
++ xn = 3.0
++ vsat = 9.884931225e+05 lvsat = -2.054536397e-01 wvsat = -1.779330477e-01 pvsat = 4.355356176e-8
++ a0 = 2.112539359e+00 la0 = -2.316120674e-07 wa0 = 7.438728946e-08 pa0 = -1.820814878e-14
++ ags = 1.249999985e+00 lags = 3.619858191e-15 wags = 5.268141479e-15 pags = -1.289509388e-21
++ a1 = 0.0
++ a2 = -9.040480416e+00 la2 = 2.323643290e-06 wa2 = 2.918491330e-06 pa2 = -7.143737154e-13
++ b0 = 0.0
++ b1 = 0.0
++ keta = -1.586701126e+00 lketa = 3.814775263e-07 wketa = 5.271743253e-07 pketa = -1.290390955e-13
++ dwg = -5.722e-9
++ dwb = -1.7864e-8
++ pclm = 2.341101211e+00 lpclm = -3.706975139e-07 wpclm = -2.410278567e-08 ppclm = 5.899759362e-15
++ pdiblc1 = 1.411659737e-01 lpdiblc1 = 1.140702322e-08 wpdiblc1 = 7.914155401e-08 ppdiblc1 = -1.937187388e-14
++ pdiblc2 = 6.842249906e-02 lpdiblc2 = -1.510949337e-08 wpdiblc2 = -1.436765013e-08 ppdiblc2 = 3.516841560e-15
++ pdiblcb = -9.163561431e+00 lpdiblcb = 2.187936374e-06 wpdiblcb = 3.901480314e-06 ppdiblcb = -9.549848438e-13
++ drout = 9.845326527e-01 ldrout = 3.321999964e-09 wdrout = 5.355953903e-15 pdrout = -1.311003750e-21
++ pscbe1 = 1.288436647e+09 lpscbe1 = -1.195647786e+02 wpscbe1 = -1.740870784e+02 ppscbe1 = 4.261216461e-5
++ pscbe2 = 1.551291865e-08 lpscbe2 = -1.516487932e-15 wpscbe2 = -2.600309662e-15 ppscbe2 = 6.364907976e-22
++ pvag = 0.0
++ delta = 0.01
++ fprout = 0.0
++ pdits = 0.0
++ pditsl = 0.0
++ pditsd = 0.0
++ lambda = 0.0
++ lc = 5.0e-9
+* Parameters FOR Asymmetric AND Bias-Dependent RDS Model
++ rdsw = 531.92
++ rsw = 0.0
++ rdw = 0.0
++ rdswmin = 0.0
++ rdwmin = 0.0
++ rswmin = 0.0
++ prwb = -0.32348
++ prwg = 0.02
++ wr = 1.0
+* Impact Ionization Current Model Parameters
++ alpha0 = 1.0e-10
++ alpha1 = 1.0e-10
++ beta0 = 2.401315341e+01 lbeta0 = -3.653986246e-06 wbeta0 = -3.524254723e-06 pbeta0 = 8.626494497e-13
+* Gidl Induced Drain Leakage Model Parameters
++ agidl = -1.520812651e-07 lagidl = 3.794197034e-14 wagidl = 5.212415942e-14 pagidl = -1.275869112e-20
++ bgidl = 1.000000010e+09 lbgidl = -2.519254684e-06 wbgidl = -3.666381836e-06 pbgidl = 8.974385262e-13
++ cgidl = 300.0
++ egidl = 0.1
+* Gate Dielectric Tunneling Current Model Parameters
++ toxref = 4.23e-9
++ dlcig = 0.0
++ aigbacc = 0.43
++ bigbacc = 0.054
++ cigbacc = 0.075
++ nigbacc = 1.0
++ aigbinv = 0.35
++ bigbinv = 0.03
++ cigbinv = 0.006
++ eigbinv = 1.1
++ nigbinv = 3.0
++ aigc = 0.43
++ bigc = 0.054
++ cigc = 0.075
++ aigsd = 0.43
++ bigsd = 0.054
++ cigsd = 0.075
++ nigc = 1.0
++ poxedge = 1.0
++ pigcd = 1.0
++ ntox = 1.0
++ vfbsdoff = 0.0
+* Charge AND Capacitance Model Parameters
++ dlc = -2.31875e-8
++ dwc = 2.252e-8
++ xpart = 0.0
++ cgso = 6.9684e-11
++ cgdo = 6.9684e-11
++ cgbo = 0.0
++ cgdl = 8.82664e-12
++ cgsl = 8.82664e-12
++ clc = 1.0e-7
++ cle = 0.6
++ cf = 1.2e-11
++ ckappas = 0.6
++ vfbcv = -0.1446893
++ acde = 0.552
++ moin = 14.504
++ noff = 4.0
++ voffcv = -0.1375
+* High-Speed/RF Model Parameters
++ xrcrg1 = 12.0
++ xrcrg2 = 1.0
++ rbpb = 50.0
++ rbpd = 50.0
++ rbps = 50.0
++ rbdb = 50.0
++ rbsb = 50.0
++ gbmin = 1.0e-12
+* Flicker AND Thermal Noise Model Parameters
++ ef = 0.88
++ noia = 1.2e+41
++ noib = 2.0e+25
++ noic = 0.0
++ em = 41000000.0
++ ntnoi = 1.0
++ lintnoi = -6.0e-8
++ af = 1.0
++ kf = 0.0
++ tnoia = 1.5
++ tnoib = 3.5
++ rnoia = 0.577
++ rnoib = 0.37
+* Layout-Dependent Parasitics Model Parameters
++ xl = 0.0
++ xw = 0.0
++ dmcg = 0.0
++ dmdg = 0.0
++ dmcgt = 0.0
++ xgw = 0.0
++ xgl = 0.0
++ ngcon = 1.0
+* Asymmetric Source/Drain Junction Diode Model Parameters
++ jss = 2.17e-5
++ jsws = 8.2e-10
++ ijthsfwd = 0.1
++ ijthsrev = 0.1
++ bvs = 12.8
++ xjbvs = 1.0
++ pbs = 0.6587
++ cjs = 0.000792710451
++ mjs = 0.34629
++ pbsws = 0.7418
++ cjsws = 1.01401195e-10
++ mjsws = 0.26859
++ pbswgs = 1.3925
++ cjswgs = 2.7096997e-10
++ mjswgs = 0.70393
+* Temperature Dependence Parameters
++ tnom = 30.0
++ kt1 = 5.950906407e-01 lkt1 = -2.781159596e-07 wkt1 = -4.531597434e-07 pkt1 = 1.109221762e-13
++ kt2 = 1.131083619e+00 lkt2 = -2.872230530e-07 wkt2 = -4.015742596e-07 pkt2 = 9.829533938e-14
++ at = 1.185891568e+05 lat = -3.316250091e-03 wat = 1.683177773e-01 pat = -4.119998395e-8
++ ute = -2.299514599e+00 lute = 4.588269676e-07 wute = -3.451785524e-15 pute = 8.449108080e-22
++ ua1 = -1.102559745e-09 lua1 = 3.416789124e-16 wua1 = -9.065908965e-16 pua1 = 2.219107867e-22
++ ub1 = 5.406746700e-18 lub1 = -1.310078073e-24 wub1 = -1.620301706e-25 pub1 = 3.966093500e-32
++ uc1 = -9.345371040e-10 luc1 = 2.144723700e-16 wuc1 = 3.744968574e-16 puc1 = -9.166746826e-23
++ kt1l = 0.0
++ prt = 0.0
++ tvoff = 0.0
++ njs = 1.2556
++ tpb = 0.0019551
++ tcj = 0.0012407
++ tpbsw = 0.00014242
++ tcjsw = 0.0
++ tpbswg = 0.0
++ tcjswg = 2.0e-12
++ xtis = 2.0
++ tvfbsdoff = 0.0
+* DW AND DL Parameters
++ ll = 0.0
++ wl = 0.0
++ lln = 1.0
++ wln = 1.0
++ lw = 0.0
++ ww = 0.0
++ lwn = 1.0
++ wwn = 1.0
++ lwl = 0.0
++ wwl = 0.0
++ llc = 0.0
++ wlc = 0.0
++ lwc = 0.0
++ wwc = 0.0
++ lwlc = 0.0
++ wwlc = 0.0
+* Stress Parameters
++ saref = 1.04e-6
++ sbref = 1.04e-6
++ kvth0 = 2.65e-8
++ lkvth0 = 0.0
++ wkvth0 = 2.5e-7
++ pkvth0 = 0.0
++ llodvth = 0.0
++ wlodvth = 1.0
++ wlod = 0.0
++ stk2 = 0.0
++ lodk2 = 1.0
++ lodeta0 = 1.0
++ ku0 = 4.5e-8
++ lku0 = 0.0
++ wku0 = 2.5e-7
++ pku0 = 0.0
++ tku0 = 0.0
++ llodku0 = 0.0
++ wlodku0 = 1.0
++ kvsat = 0.4
++ steta0 = 0.0
+* Well Proximity Effect Parameters
+.ends sky130_fd_pr__special_pfet_01v8_hvt

--- a/cells/special_pfet_01v8_hvt/sky130_fd_pr__special_pfet_01v8_hvt__subvt_mismatch.corner.spice
+++ b/cells/special_pfet_01v8_hvt/sky130_fd_pr__special_pfet_01v8_hvt__subvt_mismatch.corner.spice
@@ -1,0 +1,23 @@
+* Copyright 2020 The SkyWater PDK Authors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+
+* SKY130 Spice File.
+.param sky130_fd_pr__special_pfet_01v8_hvt__toxe_slope= 5.00e-3
+.param sky130_fd_pr__special_pfet_01v8_hvt__vth0_slope= 7.50e-3
+.param sky130_fd_pr__special_pfet_01v8_hvt__nfactor_slope=0.05
+.param sky130_fd_pr__special_pfet_01v8_hvt__nfactor_slope1=0.05
+.param sky130_fd_pr__special_pfet_01v8_hvt__voff_slope=0.023
+.param sky130_fd_pr__special_pfet_01v8_hvt__voff_slope1=0.023
+.param sky130_fd_pr__special_pfet_01v8_hvt__lint_slope=0.0
+.param sky130_fd_pr__special_pfet_01v8_hvt__wint_slope=0.0

--- a/cells/special_pfet_01v8_hvt/sky130_fd_pr__special_pfet_01v8_hvt__tt.corner.spice
+++ b/cells/special_pfet_01v8_hvt/sky130_fd_pr__special_pfet_01v8_hvt__tt.corner.spice
@@ -1,0 +1,52 @@
+* Copyright 2020 The SkyWater PDK Authors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+
+* SKY130 Spice File.
+* Number of bins: 1
+.param
++ sky130_fd_pr__special_pfet_01v8_hvt__toxe_mult = 1.0
++ sky130_fd_pr__special_pfet_01v8_hvt__rshp_mult = 1.0
++ sky130_fd_pr__special_pfet_01v8_hvt__overlap_mult = 0.98867
++ sky130_fd_pr__special_pfet_01v8_hvt__lint_diff = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__wint_diff = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__dlc_diff = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__dwc_diff = 0.0
+*
+* sky130_fd_pr__special_pfet_01v8_hvt, Bin 000, W = 0.36, L = 0.15
+* ------------------------------------
++ sky130_fd_pr__special_pfet_01v8_hvt__k2_diff_0 = -0.020934
++ sky130_fd_pr__special_pfet_01v8_hvt__rdsw_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__pdits_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__ua_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__pclm_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__ub_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__kt1_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__bgidl_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__tvoff_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__cgidl_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__ags_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__a0_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__voff_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__pditsd_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__agidl_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__keta_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__b0_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__b1_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__vsat_diff_0 = 81981.0
++ sky130_fd_pr__special_pfet_01v8_hvt__eta0_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__u0_diff_0 = -0.00017582
++ sky130_fd_pr__special_pfet_01v8_hvt__nfactor_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__vth0_diff_0 = 0.020586
+*
+.include "sky130_fd_pr__special_pfet_01v8_hvt__tt.pm3.spice"

--- a/cells/special_pfet_01v8_hvt/sky130_fd_pr__special_pfet_01v8_hvt__tt.pm3.spice
+++ b/cells/special_pfet_01v8_hvt/sky130_fd_pr__special_pfet_01v8_hvt__tt.pm3.spice
@@ -1,0 +1,306 @@
+* Copyright 2020 The SkyWater PDK Authors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+
+* SKY130 Spice File.
+.param sky130_fd_pr__special_pfet_01v8_hvt__toxe_slope_spectre = 0.0
+.param sky130_fd_pr__special_pfet_01v8_hvt__vth0_slope_spectre = 0.0
+.param sky130_fd_pr__special_pfet_01v8_hvt__voff_slope_spectre = 0.0
+.param sky130_fd_pr__special_pfet_01v8_hvt__nfactor_slope_spectre = 0.0
+* statistics {
+*   process {
+*   }
+*   mismatch {
+*     vary sky130_fd_pr__special_pfet_01v8_hvt__toxe_slope_spectre dist=gauss std = 1.0
+*     vary sky130_fd_pr__special_pfet_01v8_hvt__vth0_slope_spectre dist=gauss std = 1.0
+*     vary sky130_fd_pr__special_pfet_01v8_hvt__voff_slope_spectre dist=gauss std = 1.0
+*     vary sky130_fd_pr__special_pfet_01v8_hvt__nfactor_slope_spectre dist=gauss std = 1.0
+*   }
+* }
+.subckt  sky130_fd_pr__special_pfet_01v8_hvt d g s b
++
+.param  l = 1 w = 1 nf = 1.0 ad = 0 as = 0 pd = 0 ps = 0 nrd = 0 nrs = 0 sa = 0 sb = 0 sd = 0 mult = 1
+msky130_fd_pr__special_pfet_01v8_hvt d g s b sky130_fd_pr__special_pfet_01v8_hvt__model l = {l} w = {w} nf = {nf} ad = {ad} as = {as} pd = {pd} ps = {ps} nrd = {nrd} nrs = {nrs} sa = {sa} sb = {sb} sd = {sd}
+.model sky130_fd_pr__special_pfet_01v8_hvt__model.0 pmos
+* Model Flag Parameters
++ lmin = 1.5e-07 lmax = 1.8e-07 wmin = 3.6e-07 wmax = 4.2e-7
++ level = 54.0
++ version = 4.5
++ binunit = 2.0
++ mobmod = 0.0
++ capmod = 2.0
++ igcmod = 0.0
++ igbmod = 0.0
++ geomod = 0.0
++ diomod = 1.0
++ rdsmod = 0.0
++ rbodymod = 1.0
++ rgatemod = 0.0
++ permod = 1.0
++ acnqsmod = 0.0
++ trnqsmod = 0.0
++ fnoimod = 1.0
++ tnoimod = 1.0
++ tempmod = 0.0
+* Process Parameters
+*(mismatch parameter sky130_fd_pr__special_pfet_01v8_hvt__toxe_slope_spectre)
++ toxe = {4.23e-09+MC_MM_SWITCH*AGAUSS(0,1.0,1)*(4.23e-9*1.0*(sky130_fd_pr__special_pfet_01v8_hvt__toxe_slope/sqrt(l*w*mult)))}
++ toxm = 4.23e-9
++ dtox = 0.0
++ epsrox = 3.9
++ xj = 1.5e-7
++ ngate = 1.0e+23
++ ndep = 1.7e+17
++ nsd = 1.0e+20
++ rsh = 1.0
++ rshg = 0.1
+* Basic Model Parameters
++ wint = 9.364e-9
++ lint = -2.026e-8
+*(mismatch parameter sky130_fd_pr__special_pfet_01v8_hvt__vth0_slope_spectre)
++ vth0 = {-1.997749953e-01+MC_MM_SWITCH*AGAUSS(0,1.0,1)*(sky130_fd_pr__special_pfet_01v8_hvt__vth0_slope/sqrt(l*w*mult))} lvth0 = -1.873244639e-07 wvth0 = -2.784328784e-07 pvth0 = 6.140001835e-14
++ k1 = -1.942612612e+00 lk1 = 6.161894372e-07 wk1 = 8.145174970e-07 pk1 = -1.796173984e-13
++ k2 = -8.663270902e-02 lk2 = -1.053000443e-08 wk2 = 1.525480424e-07 pk2 = -3.363989431e-14
++ k3 = -13.778
++ k3b = 2.0
++ w0 = 0.0
++ dvt0 = 4.05
++ dvt1 = 0.3
++ dvt2 = 0.03
++ dvt0w = -4.254
++ dvt1w = 1147200.0
++ dvt2w = -0.00896
++ dsub = 7.017835139e+00 ldsub = -1.401558843e-06 wdsub = -2.103771966e-06 pdsub = 4.639237939e-13
++ minv = 0.0
++ voffl = 0.0
++ lpe0 = 0.0
++ lpeb = 0.0
++ vbm = -3.0
++ dvtp0 = 0.0
++ dvtp1 = 0.0
++ phin = 0.0
++ cdsc = 0.0
++ cdscb = 0.0
++ cdscd = 0.0
++ cit = 1.0e-5
+*(mismatch parameter sky130_fd_pr__special_pfet_01v8_hvt__voff_slope_spectre)
++ voff = {4.853301413e-01+MC_MM_SWITCH*AGAUSS(0,1.0,1)*(sky130_fd_pr__special_pfet_01v8_hvt__voff_slope/sqrt(l*w*mult))} lvoff = -1.646287895e-07 wvoff = -2.746055237e-07 pvoff = 6.055601009e-14
+*(mismatch parameter sky130_fd_pr__special_pfet_01v8_hvt__nfactor_slope_spectre)
++ nfactor = {7.365099587e+00+MC_MM_SWITCH*AGAUSS(0,1.0,1)*(sky130_fd_pr__special_pfet_01v8_hvt__nfactor_slope/sqrt(l*w*mult))} lnfactor = -1.200188742e-06 wnfactor = -4.340729115e-06 pnfactor = 9.572175843e-13
++ eta0 = 8.400758601e+00 leta0 = -1.744480487e-06 weta0 = -3.174365925e-06 peta0 = 7.000111738e-13
++ etab = 4.590023598e-01 letab = -1.012205786e-07 wetab = -1.826105146e-07 petab = 4.026927068e-14
++ u0 = -3.472902665e-03 lu0 = 1.232048033e-09 wu0 = -1.551885481e-09 pu0 = 3.422217863e-16
++ ua = -3.435785141e-09 lua = 1.733622700e-16 wua = -1.134355920e-15 pua = 2.501481675e-22
++ ub = 2.657584049e-18 lub = -6.720460536e-26 wub = 1.066698111e-24 pub = -2.352282675e-31
++ uc = -3.742083373e-10 luc = 8.257732575e-17 wuc = 1.997496245e-16 puc = -4.404878720e-23
++ ud = 0.0
++ up = 0.0
++ lp = 1.0
++ eu = 1.67
++ vtl = 0.0
++ xn = 3.0
++ vsat = 3.912086591e+06 lvsat = -8.262539486e-01 wvsat = -1.365983273e+00 pvsat = 3.012266314e-7
++ a0 = 1.977516561e+00 la0 = -1.788861682e-07 wa0 = 8.563083787e-08 pa0 = -1.888331237e-14
++ ags = 1.249999985e+00 lags = 3.332713661e-15 wags = 6.064414748e-15 pags = -1.337324473e-21
++ a1 = 0.0
++ a2 = -9.073383837e+00 la2 = 2.100647011e-06 wa2 = 3.359617749e-06 pa2 = -7.408629060e-13
++ b0 = 0.0
++ b1 = 0.0
++ keta = -1.610291043e+00 lketa = 3.488785845e-07 wketa = 6.068560841e-07 pketa = -1.338239037e-13
++ dwg = -5.722e-9
++ dwb = -1.7864e-8
++ pclm = 2.179197569e+00 lpclm = -2.982617346e-07 wpclm = -2.774589244e-08 ppclm = 6.118524200e-15
++ pdiblc1 = 1.164651831e-01 lpdiblc1 = 1.572370822e-08 wpdiblc1 = 9.110370374e-08 ppdiblc1 = -2.009018875e-14
++ pdiblc2 = 6.689112786e-02 lpdiblc2 = -1.327458055e-08 wpdiblc2 = -1.653930299e-08 ppdiblc2 = 3.647247095e-15
++ pdiblcb = -9.631244073e+00 lpdiblcb = 2.074264943e-06 wpdiblcb = 4.491184323e-06 ppdiblcb = -9.903959668e-13
++ drout = 9.860653258e-01 ldrout = 2.654834583e-09 wdrout = 6.165500110e-15 pdrout = -1.359615975e-21
++ pscbe1 = 1.299183743e+09 lpscbe1 = -1.100869344e+02 wpscbe1 = -2.004001287e+02 ppscbe1 = 4.419223639e-5
++ pscbe2 = 1.579775404e-08 lpscbe2 = -1.429029524e-15 wpscbe2 = -2.993343308e-15 ppscbe2 = 6.600920663e-22
++ pvag = 0.0
++ delta = 0.01
++ fprout = 0.0
++ pdits = 0.0
++ pditsl = 0.0
++ pditsd = 0.0
++ lambda = 0.0
++ lc = 5.0e-9
+* Parameters FOR Asymmetric AND Bias-Dependent RDS Model
++ rdsw = 531.92
++ rsw = 0.0
++ rdw = 0.0
++ rdswmin = 0.0
++ rdwmin = 0.0
++ rswmin = 0.0
++ prwb = -0.32348
++ prwg = 0.02
++ wr = 1.0
+* Impact Ionization Current Model Parameters
++ alpha0 = 1.0e-10
++ alpha1 = 1.0e-10
++ beta0 = 2.366162204e+01 lbeta0 = -3.214389391e-06 wbeta0 = -4.056941542e-06 pbeta0 = 8.946367488e-13
+* Gidl Induced Drain Leakage Model Parameters
++ agidl = -1.543105806e-07 lagidl = 3.467387114e-14 wagidl = 6.000266278e-14 pagidl = -1.323178720e-20
++ bgidl = 1.000000011e+09 lbgidl = -2.319414139e-06 wbgidl = -4.220550537e-06 pbgidl = 9.307160378e-13
++ cgidl = 300.0
++ egidl = 0.1
+* Gate Dielectric Tunneling Current Model Parameters
++ toxref = 4.23e-9
++ dlcig = 0.0
++ aigbacc = 0.43
++ bigbacc = 0.054
++ cigbacc = 0.075
++ nigbacc = 1.0
++ aigbinv = 0.35
++ bigbinv = 0.03
++ cigbinv = 0.006
++ eigbinv = 1.1
++ nigbinv = 3.0
++ aigc = 0.43
++ bigc = 0.054
++ cigc = 0.075
++ aigsd = 0.43
++ bigsd = 0.054
++ cigsd = 0.075
++ nigc = 1.0
++ poxedge = 1.0
++ pigcd = 1.0
++ ntox = 1.0
++ vfbsdoff = 0.0
+* Charge AND Capacitance Model Parameters
++ dlc = -1.106e-8
++ dwc = 0.0
++ xpart = 0.0
++ cgso = 5.93202e-11
++ cgdo = 5.93202e-11
++ cgbo = 0.0
++ cgdl = 7.513892e-12
++ cgsl = 7.513892e-12
++ clc = 1.0e-7
++ cle = 0.6
++ cf = 1.2e-11
++ ckappas = 0.6
++ vfbcv = -0.1446893
++ acde = 0.552
++ moin = 14.504
++ noff = 4.0
++ voffcv = -0.1375
+* High-Speed/RF Model Parameters
++ xrcrg1 = 12.0
++ xrcrg2 = 1.0
++ rbpb = 50.0
++ rbpd = 50.0
++ rbps = 50.0
++ rbdb = 50.0
++ rbsb = 50.0
++ gbmin = 1.0e-12
+* Flicker AND Thermal Noise Model Parameters
++ ef = 0.88
++ noia = 1.2e+41
++ noib = 2.0e+25
++ noic = 0.0
++ em = 41000000.0
++ ntnoi = 1.0
++ lintnoi = -6.0e-8
++ af = 1.0
++ kf = 0.0
++ tnoia = 1.5
++ tnoib = 3.5
++ rnoia = 0.577
++ rnoib = 0.37
+* Layout-Dependent Parasitics Model Parameters
++ xl = 0.0
++ xw = 0.0
++ dmcg = 0.0
++ dmdg = 0.0
++ dmcgt = 0.0
++ xgw = 0.0
++ xgl = 0.0
++ ngcon = 1.0
+* Asymmetric Source/Drain Junction Diode Model Parameters
++ jss = 2.17e-5
++ jsws = 8.2e-10
++ ijthsfwd = 0.1
++ ijthsrev = 0.1
++ bvs = 12.8
++ xjbvs = 1.0
++ pbs = 0.6587
++ cjs = 0.0007432633326
++ mjs = 0.34629
++ pbsws = 0.7418
++ cjsws = 9.5078641e-11
++ mjsws = 0.26859
++ pbswgs = 1.3925
++ cjswgs = 2.54074486e-10
++ mjswgs = 0.70393
+* Temperature Dependence Parameters
++ tnom = 30.0
++ kt1 = 6.383460612e-01 lkt1 = -2.600958558e-07 wkt1 = -5.216542880e-07 pkt1 = 1.150352036e-13
++ kt2 = 1.150606588e+00 lkt2 = -2.630670379e-07 wkt2 = -4.622717210e-07 pkt2 = 1.019401599e-13
++ at = 5.333259814e+04 lat = 1.140273678e-02 wat = 1.937588049e-01 pat = -4.272769165e-8
++ ute = -2.087825043e+00 lute = 3.666795630e-07 wute = -3.973519291e-15 pute = 8.762401915e-22
++ ua1 = -6.016759380e-10 lua1 = 1.973667094e-16 wua1 = -1.043621009e-15 pua1 = 2.301393049e-22
++ ub1 = 4.863660387e-18 lub1 = -1.060499730e-24 wub1 = -1.865208340e-25 pub1 = 4.113157431e-32
++ uc1 = -9.773734095e-10 luc1 = 2.026663501e-16 wuc1 = 4.311016023e-16 puc1 = -9.506652534e-23
++ kt1l = 0.0
++ prt = 0.0
++ tvoff = 0.0
++ njs = 1.2556
++ tpb = 0.0019551
++ tcj = 0.0012407
++ tpbsw = 0.00014242
++ tcjsw = 0.0
++ tpbswg = 0.0
++ tcjswg = 2.0e-12
++ xtis = 2.0
++ tvfbsdoff = 0.0
+* DW AND DL Parameters
++ ll = 0.0
++ wl = 0.0
++ lln = 1.0
++ wln = 1.0
++ lw = 0.0
++ ww = 0.0
++ lwn = 1.0
++ wwn = 1.0
++ lwl = 0.0
++ wwl = 0.0
++ llc = 0.0
++ wlc = 0.0
++ lwc = 0.0
++ wwc = 0.0
++ lwlc = 0.0
++ wwlc = 0.0
+* Stress Parameters
++ saref = 1.04e-6
++ sbref = 1.04e-6
++ kvth0 = 2.65e-8
++ lkvth0 = 0.0
++ wkvth0 = 2.5e-7
++ pkvth0 = 0.0
++ llodvth = 0.0
++ wlodvth = 1.0
++ wlod = 0.0
++ stk2 = 0.0
++ lodk2 = 1.0
++ lodeta0 = 1.0
++ ku0 = 4.5e-8
++ lku0 = 0.0
++ wku0 = 2.5e-7
++ pku0 = 0.0
++ tku0 = 0.0
++ llodku0 = 0.0
++ wlodku0 = 1.0
++ kvsat = 0.4
++ steta0 = 0.0
+* Well Proximity Effect Parameters
+.ends sky130_fd_pr__special_pfet_01v8_hvt

--- a/cells/special_pfet_01v8_hvt/sky130_fd_pr__special_pfet_01v8_hvt__tt_correln.corner.spice
+++ b/cells/special_pfet_01v8_hvt/sky130_fd_pr__special_pfet_01v8_hvt__tt_correln.corner.spice
@@ -1,0 +1,53 @@
+* Copyright 2020 The SkyWater PDK Authors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+
+* SKY130 Spice File.
+.param sky130_fd_pr__special_pfet_01v8_hvt__vth0_correldiff = -0.022
+* Number of bins: 1
+.param
++ sky130_fd_pr__special_pfet_01v8_hvt__toxe_mult = 1.0
++ sky130_fd_pr__special_pfet_01v8_hvt__rshp_mult = 1.0
++ sky130_fd_pr__special_pfet_01v8_hvt__overlap_mult = 0.98867
++ sky130_fd_pr__special_pfet_01v8_hvt__lint_diff = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__wint_diff = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__dlc_diff = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__dwc_diff = 0.0
+*
+* sky130_fd_pr__special_pfet_01v8_hvt, Bin 000, W = 0.36, L = 0.15
+* ------------------------------------
++ sky130_fd_pr__special_pfet_01v8_hvt__k2_diff_0 = -0.020934
++ sky130_fd_pr__special_pfet_01v8_hvt__rdsw_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__pdits_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__ua_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__pclm_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__ub_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__kt1_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__bgidl_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__tvoff_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__cgidl_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__ags_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__a0_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__voff_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__pditsd_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__agidl_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__keta_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__b0_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__b1_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__vsat_diff_0 = 81981.0
++ sky130_fd_pr__special_pfet_01v8_hvt__eta0_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__u0_diff_0 = -0.00017582
++ sky130_fd_pr__special_pfet_01v8_hvt__nfactor_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__vth0_diff_0 = ' 0.020586 + sky130_fd_pr__special_pfet_01v8_hvt__vth0_correldiff'
+*
+.include "sky130_fd_pr__special_pfet_01v8_hvt.pm3.spice"

--- a/cells/special_pfet_01v8_hvt/sky130_fd_pr__special_pfet_01v8_hvt__tt_correlp.corner.spice
+++ b/cells/special_pfet_01v8_hvt/sky130_fd_pr__special_pfet_01v8_hvt__tt_correlp.corner.spice
@@ -1,0 +1,53 @@
+* Copyright 2020 The SkyWater PDK Authors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+
+* SKY130 Spice File.
+.param sky130_fd_pr__special_pfet_01v8_hvt__vth0_correldiff = 0.022
+* Number of bins: 1
+.param
++ sky130_fd_pr__special_pfet_01v8_hvt__toxe_mult = 1.0
++ sky130_fd_pr__special_pfet_01v8_hvt__rshp_mult = 1.0
++ sky130_fd_pr__special_pfet_01v8_hvt__overlap_mult = 0.98867
++ sky130_fd_pr__special_pfet_01v8_hvt__lint_diff = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__wint_diff = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__dlc_diff = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__dwc_diff = 0.0
+*
+* sky130_fd_pr__special_pfet_01v8_hvt, Bin 000, W = 0.36, L = 0.15
+* ------------------------------------
++ sky130_fd_pr__special_pfet_01v8_hvt__k2_diff_0 = -0.020934
++ sky130_fd_pr__special_pfet_01v8_hvt__rdsw_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__pdits_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__ua_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__pclm_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__ub_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__kt1_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__bgidl_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__tvoff_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__cgidl_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__ags_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__a0_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__voff_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__pditsd_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__agidl_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__keta_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__b0_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__b1_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__vsat_diff_0 = 81981.0
++ sky130_fd_pr__special_pfet_01v8_hvt__eta0_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__u0_diff_0 = -0.00017582
++ sky130_fd_pr__special_pfet_01v8_hvt__nfactor_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__vth0_diff_0 = ' 0.020586 + sky130_fd_pr__special_pfet_01v8_hvt__vth0_correldiff'
+*
+.include "sky130_fd_pr__special_pfet_01v8_hvt.pm3.spice"

--- a/cells/special_pfet_01v8_hvt/sky130_fd_pr__special_pfet_01v8_hvt__tt_leak.corner.spice
+++ b/cells/special_pfet_01v8_hvt/sky130_fd_pr__special_pfet_01v8_hvt__tt_leak.corner.spice
@@ -1,0 +1,52 @@
+* Copyright 2020 The SkyWater PDK Authors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+
+* SKY130 Spice File.
+* Number of bins: 1
+.param
++ sky130_fd_pr__special_pfet_01v8_hvt__toxe_mult = 1.0
++ sky130_fd_pr__special_pfet_01v8_hvt__rshp_mult = 1.0
++ sky130_fd_pr__special_pfet_01v8_hvt__overlap_mult = 0.98867
++ sky130_fd_pr__special_pfet_01v8_hvt__lint_diff = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__wint_diff = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__dlc_diff = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__dwc_diff = 0.0
+*
+* sky130_fd_pr__special_pfet_01v8_hvt, Bin 000, W = 0.36, L = 0.15
+* ------------------------------------
++ sky130_fd_pr__special_pfet_01v8_hvt__k2_diff_0 = -0.020934
++ sky130_fd_pr__special_pfet_01v8_hvt__rdsw_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__pdits_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__ua_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__pclm_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__ub_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__kt1_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__bgidl_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__tvoff_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__cgidl_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__ags_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__a0_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__voff_diff_0 = -0.11116
++ sky130_fd_pr__special_pfet_01v8_hvt__pditsd_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__agidl_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__keta_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__b0_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__b1_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__vsat_diff_0 = 81981.0
++ sky130_fd_pr__special_pfet_01v8_hvt__eta0_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__u0_diff_0 = -0.00017582
++ sky130_fd_pr__special_pfet_01v8_hvt__nfactor_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__vth0_diff_0 = 0.020045
+*
+.include "sky130_fd_pr__special_pfet_01v8_hvt.pm3.spice"

--- a/cells/special_pfet_01v8_hvt/sky130_fd_pr__special_pfet_01v8_hvt__tt_leak.pm3.spice
+++ b/cells/special_pfet_01v8_hvt/sky130_fd_pr__special_pfet_01v8_hvt__tt_leak.pm3.spice
@@ -1,0 +1,306 @@
+* Copyright 2020 The SkyWater PDK Authors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+
+* SKY130 Spice File.
+.param sky130_fd_pr__special_pfet_01v8_hvt__toxe_slope_spectre = 0.0
+.param sky130_fd_pr__special_pfet_01v8_hvt__vth0_slope_spectre = 0.0
+.param sky130_fd_pr__special_pfet_01v8_hvt__voff_slope_spectre = 0.0
+.param sky130_fd_pr__special_pfet_01v8_hvt__nfactor_slope_spectre = 0.0
+* statistics {
+*   process {
+*   }
+*   mismatch {
+*     vary sky130_fd_pr__special_pfet_01v8_hvt__toxe_slope_spectre dist=gauss std = 1.0
+*     vary sky130_fd_pr__special_pfet_01v8_hvt__vth0_slope_spectre dist=gauss std = 1.0
+*     vary sky130_fd_pr__special_pfet_01v8_hvt__voff_slope_spectre dist=gauss std = 1.0
+*     vary sky130_fd_pr__special_pfet_01v8_hvt__nfactor_slope_spectre dist=gauss std = 1.0
+*   }
+* }
+.subckt  sky130_fd_pr__special_pfet_01v8_hvt d g s b
++ 
+.param  l = 1 w = 1 nf = 1.0 ad = 0 as = 0 pd = 0 ps = 0 nrd = 0 nrs = 0 sa = 0 sb = 0 sd = 0 mult = 1
+msky130_fd_pr__special_pfet_01v8_hvt d g s b sky130_fd_pr__special_pfet_01v8_hvt__model l = {l} w = {w} nf = {nf} ad = {ad} as = {as} pd = {pd} ps = {ps} nrd = {nrd} nrs = {nrs} sa = {sa} sb = {sb} sd = {sd}
+.model sky130_fd_pr__special_pfet_01v8_hvt__model.0 pmos
+* Model Flag Parameters
++ lmin = 1.5e-07 lmax = 1.8e-07 wmin = 3.6e-07 wmax = 4.2e-7
++ level = 54.0
++ version = 4.5
++ binunit = 2.0
++ mobmod = 0.0
++ capmod = 2.0
++ igcmod = 0.0
++ igbmod = 0.0
++ geomod = 0.0
++ diomod = 1.0
++ rdsmod = 0.0
++ rbodymod = 1.0
++ rgatemod = 0.0
++ permod = 1.0
++ acnqsmod = 0.0
++ trnqsmod = 0.0
++ fnoimod = 1.0
++ tnoimod = 1.0
++ tempmod = 0.0
+* Process Parameters
+*(mismatch parameter sky130_fd_pr__special_pfet_01v8_hvt__toxe_slope_spectre)
++ toxe = {4.23e-09+MC_MM_SWITCH*AGAUSS(0,1.0,1)*(4.23e-9*1.0*(sky130_fd_pr__special_pfet_01v8_hvt__toxe_slope/sqrt(l*w*mult)))}
++ toxm = 4.23e-9
++ dtox = 0.0
++ epsrox = 3.9
++ xj = 1.5e-7
++ ngate = 1.0e+23
++ ndep = 1.7e+17
++ nsd = 1.0e+20
++ rsh = 1.0
++ rshg = 0.1
+* Basic Model Parameters
++ wint = 9.364e-9
++ lint = -2.026e-8
+*(mismatch parameter sky130_fd_pr__special_pfet_01v8_hvt__vth0_slope_spectre)
++ vth0 = {-2.280380644e-01+MC_MM_SWITCH*AGAUSS(0,1.0,1)*(sky130_fd_pr__special_pfet_01v8_hvt__vth0_slope/sqrt(l*w*mult))} lvth0 = -1.813216737e-07 wvth0 = -2.702289094e-07 pvth0 = 5.959087909e-14
++ k1 = -1.942612612e+00 lk1 = 6.161894372e-07 wk1 = 8.145174970e-07 pk1 = -1.796173984e-13
++ k2 = -8.663270902e-02 lk2 = -1.053000443e-08 wk2 = 1.525480424e-07 pk2 = -3.363989431e-14
++ k3 = -13.778
++ k3b = 2.0
++ w0 = 0.0
++ dvt0 = 4.05
++ dvt1 = 0.3
++ dvt2 = 0.03
++ dvt0w = -4.254
++ dvt1w = 1147200.0
++ dvt2w = -0.00896
++ dsub = 7.017835139e+00 ldsub = -1.401558843e-06 wdsub = -2.103771966e-06 pdsub = 4.639237939e-13
++ minv = 0.0
++ voffl = 0.0
++ lpe0 = 0.0
++ lpeb = 0.0
++ vbm = -3.0
++ dvtp0 = 0.0
++ dvtp1 = 0.0
++ phin = 0.0
++ cdsc = 0.0
++ cdscb = 0.0
++ cdscd = 0.0
++ cit = 1.0e-5
+*(mismatch parameter sky130_fd_pr__special_pfet_01v8_hvt__voff_slope_spectre)
++ voff = {6.584120060e-02+MC_MM_SWITCH*AGAUSS(0,1.0,1)*(sky130_fd_pr__special_pfet_01v8_hvt__voff_slope/sqrt(l*w*mult))} lvoff = -9.907041178e-08 wvoff = -1.970736678e-07 pvoff = 4.345868523e-14
+*(mismatch parameter sky130_fd_pr__special_pfet_01v8_hvt__nfactor_slope_spectre)
++ nfactor = {1.712485402e+01+MC_MM_SWITCH*AGAUSS(0,1.0,1)*(sky130_fd_pr__special_pfet_01v8_hvt__nfactor_slope/sqrt(l*w*mult))} lnfactor = -3.207930818e-06 wnfactor = -6.027905788e-06 pnfactor = 1.329273784e-12
++ eta0 = 8.400758601e+00 leta0 = -1.744480487e-06 weta0 = -3.174365925e-06 peta0 = 7.000111738e-13
++ etab = 4.590023598e-01 letab = -1.012205786e-07 wetab = -1.826105146e-07 petab = 4.026927068e-14
++ u0 = -3.433624693e-03 lu0 = 1.223953191e-09 wu0 = -1.558842911e-09 pu0 = 3.437560387e-16
++ ua = -3.435785141e-09 lua = 1.733622700e-16 wua = -1.134355920e-15 pua = 2.501481675e-22
++ ub = 2.657584049e-18 lub = -6.720460536e-26 wub = 1.066698111e-24 pub = -2.352282675e-31
++ uc = -3.742083373e-10 luc = 8.257732575e-17 wuc = 1.997496245e-16 puc = -4.404878720e-23
++ ud = 0.0
++ up = 0.0
++ lp = 1.0
++ eu = 1.67
++ vtl = 0.0
++ xn = 3.0
++ vsat = 3.929098756e+06 lvsat = -8.293483216e-01 wvsat = -1.364313490e+00 pvsat = 3.008584108e-7
++ a0 = 1.977516561e+00 la0 = -1.788861682e-07 wa0 = 8.563083787e-08 pa0 = -1.888331237e-14
++ ags = 1.249999985e+00 lags = 3.332713661e-15 wags = 6.064414748e-15 pags = -1.337324473e-21
++ a1 = 0.0
++ a2 = -9.073383837e+00 la2 = 2.100647011e-06 wa2 = 3.359617749e-06 pa2 = -7.408629060e-13
++ b0 = 0.0
++ b1 = 0.0
++ keta = -1.610291043e+00 lketa = 3.488785845e-07 wketa = 6.068560841e-07 pketa = -1.338239037e-13
++ dwg = -5.722e-9
++ dwb = -1.7864e-8
++ pclm = 2.179197569e+00 lpclm = -2.982617346e-07 wpclm = -2.774589244e-08 ppclm = 6.118524200e-15
++ pdiblc1 = 1.164651831e-01 lpdiblc1 = 1.572370822e-08 wpdiblc1 = 9.110370374e-08 ppdiblc1 = -2.009018875e-14
++ pdiblc2 = 6.689112786e-02 lpdiblc2 = -1.327458055e-08 wpdiblc2 = -1.653930299e-08 ppdiblc2 = 3.647247095e-15
++ pdiblcb = -9.631244073e+00 lpdiblcb = 2.074264943e-06 wpdiblcb = 4.491184323e-06 ppdiblcb = -9.903959668e-13
++ drout = 9.860653258e-01 ldrout = 2.654834583e-09 wdrout = 6.165500110e-15 pdrout = -1.359615975e-21
++ pscbe1 = 1.299183743e+09 lpscbe1 = -1.100869344e+02 wpscbe1 = -2.004001287e+02 ppscbe1 = 4.419223639e-5
++ pscbe2 = 1.579775404e-08 lpscbe2 = -1.429029524e-15 wpscbe2 = -2.993343308e-15 ppscbe2 = 6.600920663e-22
++ pvag = 0.0
++ delta = 0.01
++ fprout = 0.0
++ pdits = 0.0
++ pditsl = 0.0
++ pditsd = 0.0
++ lambda = 0.0
++ lc = 5.0e-9
+* Parameters FOR Asymmetric AND Bias-Dependent RDS Model
++ rdsw = 531.92
++ rsw = 0.0
++ rdw = 0.0
++ rdswmin = 0.0
++ rdwmin = 0.0
++ rswmin = 0.0
++ prwb = -0.32348
++ prwg = 0.02
++ wr = 1.0
+* Impact Ionization Current Model Parameters
++ alpha0 = 1.0e-10
++ alpha1 = 1.0e-10
++ beta0 = 2.366162204e+01 lbeta0 = -3.214389391e-06 wbeta0 = -4.056941542e-06 pbeta0 = 8.946367488e-13
+* Gidl Induced Drain Leakage Model Parameters
++ agidl = 0.0
++ bgidl = 1.000000011e+09 lbgidl = -2.319414139e-06 wbgidl = -4.220550537e-06 pbgidl = 9.307160378e-13
++ cgidl = 300.0
++ egidl = 0.1
+* Gate Dielectric Tunneling Current Model Parameters
++ toxref = 4.23e-9
++ dlcig = 0.0
++ aigbacc = 0.43
++ bigbacc = 0.054
++ cigbacc = 0.075
++ nigbacc = 1.0
++ aigbinv = 0.35
++ bigbinv = 0.03
++ cigbinv = 0.006
++ eigbinv = 1.1
++ nigbinv = 3.0
++ aigc = 0.43
++ bigc = 0.054
++ cigc = 0.075
++ aigsd = 0.43
++ bigsd = 0.054
++ cigsd = 0.075
++ nigc = 1.0
++ poxedge = 1.0
++ pigcd = 1.0
++ ntox = 1.0
++ vfbsdoff = 0.0
+* Charge AND Capacitance Model Parameters
++ dlc = -1.106e-8
++ dwc = 0.0
++ xpart = 0.0
++ cgso = 5.93202e-11
++ cgdo = 5.93202e-11
++ cgbo = 0.0
++ cgdl = 7.513892e-12
++ cgsl = 7.513892e-12
++ clc = 1.0e-7
++ cle = 0.6
++ cf = 1.2e-11
++ ckappas = 0.6
++ vfbcv = -0.1446893
++ acde = 0.552
++ moin = 14.504
++ noff = 4.0
++ voffcv = -0.1375
+* High-Speed/RF Model Parameters
++ xrcrg1 = 12.0
++ xrcrg2 = 1.0
++ rbpb = 50.0
++ rbpd = 50.0
++ rbps = 50.0
++ rbdb = 50.0
++ rbsb = 50.0
++ gbmin = 1.0e-12
+* Flicker AND Thermal Noise Model Parameters
++ ef = 0.88
++ noia = 1.2e+41
++ noib = 2.0e+25
++ noic = 0.0
++ em = 41000000.0
++ ntnoi = 1.0
++ lintnoi = -6.0e-8
++ af = 1.0
++ kf = 0.0
++ tnoia = 1.5
++ tnoib = 3.5
++ rnoia = 0.577
++ rnoib = 0.37
+* Layout-Dependent Parasitics Model Parameters
++ xl = 0.0
++ xw = 0.0
++ dmcg = 0.0
++ dmdg = 0.0
++ dmcgt = 0.0
++ xgw = 0.0
++ xgl = 0.0
++ ngcon = 1.0
+* Asymmetric Source/Drain Junction Diode Model Parameters
++ jss = 2.17e-5
++ jsws = 8.2e-10
++ ijthsfwd = 0.1
++ ijthsrev = 0.1
++ bvs = 12.8
++ xjbvs = 1.0
++ pbs = 0.6587
++ cjs = 0.0007432633326
++ mjs = 0.34629
++ pbsws = 0.7418
++ cjsws = 9.5078641e-11
++ mjsws = 0.26859
++ pbswgs = 1.3925
++ cjswgs = 2.54074486e-10
++ mjswgs = 0.70393
+* Temperature Dependence Parameters
++ tnom = 30.0
++ kt1 = 1.445498355e+01 lkt1 = -3.321824974e-06 wkt1 = -5.406204692e-06 pkt1 = 1.192176259e-12
++ kt2 = 1.150606588e+00 lkt2 = -2.630670379e-07 wkt2 = -4.622717210e-07 pkt2 = 1.019401599e-13
++ at = 5.333259814e+04 lat = 1.140273678e-02 wat = 1.937588049e-01 pat = -4.272769165e-8
++ ute = -2.087825043e+00 lute = 3.666795630e-07 wute = -3.973519291e-15 pute = 8.762401915e-22
++ ua1 = -6.016759380e-10 lua1 = 1.973667094e-16 wua1 = -1.043621009e-15 pua1 = 2.301393049e-22
++ ub1 = 4.863660387e-18 lub1 = -1.060499730e-24 wub1 = -1.865208340e-25 pub1 = 4.113157431e-32
++ uc1 = -9.773734095e-10 luc1 = 2.026663501e-16 wuc1 = 4.311016023e-16 puc1 = -9.506652534e-23
++ kt1l = 0.0
++ prt = 0.0
++ tvoff = 0.0
++ njs = 1.2556
++ tpb = 0.0019551
++ tcj = 0.0012407
++ tpbsw = 0.00014242
++ tcjsw = 0.0
++ tpbswg = 0.0
++ tcjswg = 2.0e-12
++ xtis = 2.0
++ tvfbsdoff = 0.0
+* DW AND DL Parameters
++ ll = 0.0
++ wl = 0.0
++ lln = 1.0
++ wln = 1.0
++ lw = 0.0
++ ww = 0.0
++ lwn = 1.0
++ wwn = 1.0
++ lwl = 0.0
++ wwl = 0.0
++ llc = 0.0
++ wlc = 0.0
++ lwc = 0.0
++ wwc = 0.0
++ lwlc = 0.0
++ wwlc = 0.0
+* Stress Parameters
++ saref = 1.04e-6
++ sbref = 1.04e-6
++ kvth0 = 2.65e-8
++ lkvth0 = 0.0
++ wkvth0 = 2.5e-7
++ pkvth0 = 0.0
++ llodvth = 0.0
++ wlodvth = 1.0
++ wlod = 0.0
++ stk2 = 0.0
++ lodk2 = 1.0
++ lodeta0 = 1.0
++ ku0 = 4.5e-8
++ lku0 = 0.0
++ wku0 = 2.5e-7
++ pku0 = 0.0
++ tku0 = 0.0
++ llodku0 = 0.0
++ wlodku0 = 1.0
++ kvsat = 0.4
++ steta0 = 0.0
+* Well Proximity Effect Parameters
+.ends sky130_fd_pr__special_pfet_01v8_hvt

--- a/cells/special_pfet_01v8_hvt/sky130_fd_pr__special_pfet_01v8_hvt__wafer.corner.spice
+++ b/cells/special_pfet_01v8_hvt/sky130_fd_pr__special_pfet_01v8_hvt__wafer.corner.spice
@@ -1,0 +1,52 @@
+* Copyright 2020 The SkyWater PDK Authors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+
+* SKY130 Spice File.
+* Number of bins: 1
+.param
++ sky130_fd_pr__special_pfet_01v8_hvt__toxe_mult = 1.0
++ sky130_fd_pr__special_pfet_01v8_hvt__rshp_mult = 1.0
++ sky130_fd_pr__special_pfet_01v8_hvt__overlap_mult = 1.0
++ sky130_fd_pr__special_pfet_01v8_hvt__lint_diff = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__wint_diff = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__dlc_diff = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__dwc_diff = 0.0
+*
+* sky130_fd_pr__special_pfet_01v8_hvt, Bin 000, W = 0.36, L = 0.15
+* ------------------------------------
++ sky130_fd_pr__special_pfet_01v8_hvt__nfactor_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__keta_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__ua_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__eta0_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__pclm_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__ub_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__tvoff_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__ags_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__cgidl_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__b0_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__b1_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__agidl_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__rdsw_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__a0_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__bgidl_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__u0_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__voff_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__k2_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__kt1_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__pdits_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__pditsd_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__vsat_diff_0 = 0.0
++ sky130_fd_pr__special_pfet_01v8_hvt__vth0_diff_0 = 0.0
+*
+.include "sky130_fd_pr__special_pfet_01v8_hvt.pm3.spice"

--- a/combined_models/corners/ff.spice
+++ b/combined_models/corners/ff.spice
@@ -1,4 +1,8 @@
 * SKY130 Spice File.
+.include "../../cells/special_nfet_01v8/sky130_fd_pr__special_nfet_01v8__ff.pm3.spice"
+.include "../../cells/special_nfet_01v8/sky130_fd_pr__special_nfet_01v8__mismatch.corner.spice"
+.include "../../cells/special_pfet_01v8_hvt/sky130_fd_pr__special_pfet_01v8_hvt__ff.pm3.spice"
+.include "../../cells/special_pfet_01v8_hvt/sky130_fd_pr__special_pfet_01v8_hvt__mismatch.corner.spice"
 .include "all.spice"
 .include "ff/legacy.spice"
 .include "ff/nonfet.spice"

--- a/combined_models/corners/fs.spice
+++ b/combined_models/corners/fs.spice
@@ -1,4 +1,8 @@
 * SKY130 Spice File.
+.include "../../cells/special_nfet_01v8/sky130_fd_pr__special_nfet_01v8__fs.pm3.spice"
+.include "../../cells/special_nfet_01v8/sky130_fd_pr__special_nfet_01v8__mismatch.corner.spice"
+.include "../../cells/special_pfet_01v8_hvt/sky130_fd_pr__special_pfet_01v8_hvt__fs.pm3.spice"
+.include "../../cells/special_pfet_01v8_hvt/sky130_fd_pr__special_pfet_01v8_hvt__mismatch.corner.spice"
 .include "all.spice"
 .include "fs/legacy.spice"
 .include "fs/nonfet.spice"

--- a/combined_models/corners/sf.spice
+++ b/combined_models/corners/sf.spice
@@ -1,4 +1,8 @@
 * SKY130 Spice File.
+.include "../../cells/special_nfet_01v8/sky130_fd_pr__special_nfet_01v8__sf.pm3.spice"
+.include "../../cells/special_nfet_01v8/sky130_fd_pr__special_nfet_01v8__mismatch.corner.spice"
+.include "../../cells/special_pfet_01v8_hvt/sky130_fd_pr__special_pfet_01v8_hvt__sf.pm3.spice"
+.include "../../cells/special_pfet_01v8_hvt/sky130_fd_pr__special_pfet_01v8_hvt__mismatch.corner.spice"
 .include "all.spice"
 .include "sf/legacy.spice"
 .include "sf/nonfet.spice"

--- a/combined_models/corners/ss.spice
+++ b/combined_models/corners/ss.spice
@@ -1,4 +1,8 @@
 * SKY130 Spice File.
+.include "../../cells/special_nfet_01v8/sky130_fd_pr__special_nfet_01v8__ss.pm3.spice"
+.include "../../cells/special_nfet_01v8/sky130_fd_pr__special_nfet_01v8__mismatch.corner.spice"
+.include "../../cells/special_pfet_01v8_hvt/sky130_fd_pr__special_pfet_01v8_hvt__ss.pm3.spice"
+.include "../../cells/special_pfet_01v8_hvt/sky130_fd_pr__special_pfet_01v8_hvt__mismatch.corner.spice"
 .include "all.spice"
 .include "ss/legacy.spice"
 .include "ss/nonfet.spice"

--- a/combined_models/corners/tt.spice
+++ b/combined_models/corners/tt.spice
@@ -1,4 +1,8 @@
 * SKY130 Spice File.
+.include "../../cells/special_nfet_01v8/sky130_fd_pr__special_nfet_01v8__tt.pm3.spice"
+.include "../../cells/special_nfet_01v8/sky130_fd_pr__special_nfet_01v8__mismatch.corner.spice"
+.include "../../cells/special_pfet_01v8_hvt/sky130_fd_pr__special_pfet_01v8_hvt__tt.pm3.spice"
+.include "../../cells/special_pfet_01v8_hvt/sky130_fd_pr__special_pfet_01v8_hvt__mismatch.corner.spice"
 .include "all.spice"
 .include "tt/legacy.spice"
 .include "tt/nonfet.spice"

--- a/combined_models/rescap/sky130_fd_pr__model__res.model.spice
+++ b/combined_models/rescap/sky130_fd_pr__model__res.model.spice
@@ -13,13 +13,6 @@
 * limitations under the License.
 
 * SKY130 Spice File.
-.param   tc1rsn_h= 1.405e-3
-.param   tc2rsn_h= 4.233e-7
-.param   tc1rsp_h= 1.369e-3
-.param   tc2rsp_h= 1.476e-6
-
-.model sky130_fd_pr__res_generic_nd__hv r tc1r = {tc1rsn_h} tc2r = {tc2rsn_h} rsh = {rdn_hv} dw = {"-tol_nfom/2-nfom_dw/2"} tnom = 30.0
-.model sky130_fd_pr__res_generic_pd__hv r tc1r = {tc1rsp_h} tc2r = {tc2rsp_h} rsh = {rdp_hv} dw = {"-tol_pfom/2-pfom_dw/2"} tnom = 30.0
 
 * Resistor model "short" defined with a fixed resistance of 0.01 ohms.
 .model short r r=0.01
@@ -31,13 +24,13 @@ R0 1 2 short
 * Subcircuit definition HV diffusion resistors
 
 .subckt sky130_fd_pr__res_generic_nd__hv t1 t2 b w=1 l=1
-r0 t1 t2 sky130_fd_pr__res_generic_nd__hv w = {w} l = {l}
+r0 t1 t2 rndiff_v5 w = {w} l = {l}
 d0 b t1 sky130_fd_pr__diode_pw2nd_11v0 area='w*l*0.5' pj='w+l'
 d1 b t2 sky130_fd_pr__diode_pw2nd_11v0 area='w*l*0.5' pj='w+l'
 .ends sky130_fd_pr__res_generic_nd__hv
 
 .subckt sky130_fd_pr__res_generic_pd__hv t1 t2 b w=1 l=1
-r0 t1 t2 sky130_fd_pr__res_generic_pd__hv w = {w} l = {l}
+r0 t1 t2 rpdiff_v5 w = {w} l = {l}
 d0 t1 b sky130_fd_pr__diode_pd2nw_11v0 area='w*l*0.5' pj='w+l'
 d1 t1 b sky130_fd_pr__diode_pd2nw_11v0 area='w*l*0.5' pj='w+l'
 .ends sky130_fd_pr__res_generic_pd__hv


### PR DESCRIPTION
Added the nFET and pFET devices used in standard cells that are less than the minimum gate width for diffusion.  The minimum gate width is 0.42um and is the limit of the continuous nFET and pFET models.  But the HD standard cell library uses some nfet_01v8 devices with 0.36 and 0.39um width gates, and some pfet_01v8_hvt devices with 0.36um width gates.  Because each of these devices has its own specific characterized model in the original discrete models, the three discrete models were ported to the combined models set.  Since they use the same model names as the continuous devices, the models were renamed to "sky130_fd_pr__special_nfet_01v8" and "sky130_fd_pr__special_pfet_01v8_hvt", using the same format as was used on similarly under-sized devices in the SRAM.  This requires changing the way the devices are extracted, and requires chaning the 200+ device instances in the HD library standard cell SPICE and CDL.  To keep the change to the standard cells from breaking the original discrete device models, the new device names were instantiated in the original discrete device models as new subcircuits that call the original subcircuit (without the "special_" prefix).