### PR TITLE
Corrected diode and BJT models

### DIFF
--- a/combined_models/continuous/models_bjt.spice
+++ b/combined_models/continuous/models_bjt.spice
@@ -325,9 +325,9 @@ Qsky130_fd_pr__npn_05v5_W1p00L2p00 c b e s nsky130_fd_pr__pnp_05v5_W0p68L0p68ar1
 *      What    : Converted from sky130_fd_pr__pnp_05v5_W0p68L0p68par model
 *                Changed the B-C capacitance variation from Pwell-Deep Nwell to
 *                Nwell-Pwell (Nwell-Substrate cap is dominated by Nwell).
+* Modified 03/08/2024  Tim Edwards  Removed substrate pin for backwards compatibility
 
-
-.subckt  sky130_fd_pr__pnp_05v5_W3p40L3p40 c b e s mult=1
+.subckt  sky130_fd_pr__pnp_05v5_W3p40L3p40 c b e mult=1
 
 +
 + 
@@ -339,7 +339,7 @@ Qsky130_fd_pr__npn_05v5_W1p00L2p00 c b e s nsky130_fd_pr__pnp_05v5_W0p68L0p68ar1
 + mm_is = {0.13*sw_mm_sky130_fd_pr__pnp_05v5_W0p68L0p68_is*mismatch_factor*MC_MM_SWITCH*AGAUSS(0,1.0,1)/sqrt(mult)}
 
 
-Qsky130_fd_pr__pnp_05v5_W3p40L3p40 c b e s sky130_fd_pr__pnp_05v5_W0p68L0p68par5x_model 
+Qsky130_fd_pr__pnp_05v5_W3p40L3p40 c b e c sky130_fd_pr__pnp_05v5_W0p68L0p68par5x_model 
 
 
 
@@ -395,9 +395,9 @@ Qsky130_fd_pr__pnp_05v5_W3p40L3p40 c b e s sky130_fd_pr__pnp_05v5_W0p68L0p68par5
 * 2021/02/19  UZMN (Usman Suriono)
 *      Why     : New infrastructure of the sky130_fd_pr__pnp_05v5_W0p68L0p68 model
 *      What    : Converted from sky130_fd_pr__pnp_05v5_W0p68L0p68par model
+* Modified 03/08/2024  Tim Edwards  Removed substrate pin for backwards compatibility
 
-
-.subckt  sky130_fd_pr__pnp_05v5_W0p68L0p68 c b e s mult=1
+.subckt  sky130_fd_pr__pnp_05v5_W0p68L0p68 c b e mult=1
 
 +
 + 
@@ -406,7 +406,7 @@ Qsky130_fd_pr__pnp_05v5_W3p40L3p40 c b e s sky130_fd_pr__pnp_05v5_W0p68L0p68par5
 + mm_bf = {sw_mm_sky130_fd_pr__pnp_05v5_W0p68L0p68_bf*mismatch_factor*MC_MM_SWITCH*AGAUSS(0,1.0,1)/sqrt(mult)}
 + mm_is = {sw_mm_sky130_fd_pr__pnp_05v5_W0p68L0p68_is*mismatch_factor*MC_MM_SWITCH*AGAUSS(0,1.0,1)/sqrt(mult)}
 
-Qsky130_fd_pr__pnp_05v5_W0p68L0p68 c b e s sky130_fd_pr__pnp_05v5_W0p68L0p68_model 
+Qsky130_fd_pr__pnp_05v5_W0p68L0p68 c b e c sky130_fd_pr__pnp_05v5_W0p68L0p68_model 
 
 
 **

--- a/models/sky130_fd_pr__model__r+c.model.spice
+++ b/models/sky130_fd_pr__model__r+c.model.spice
@@ -162,10 +162,41 @@ R0 1 2 short
 .subckt sky130_fd_pr__diode_pw2nd N P a=0 p=0
 D0 N P sky130_fd_pr__diode_pw2nd_05v5 area=a pj=p
 .ends
+
 * (corresponds to current PDK)
-.subckt sky130_fd_pr__diode_pw2nd_05v5 N P area=0 perimeter=0
-D0 N P sky130_fd_pr__diode_pw2nd_05v5 area=area pj=perimeter
+
+.subckt sky130_fd_pr__diode_pw2nd_05v5_nvt N P area=1e12 perim=1e6
+D0 N P sky130_fd_pr__diode_pw2nd_05v5_nvt area={area} pj={perim}
 .ends
+
+.subckt sky130_fd_pr__diode_pw2nd_05v5_lvt N P area=1e12 perim=1e6
+D0 N P sky130_fd_pr__diode_pw2nd_05v5_lvt area={area} pj={perim}
+.ends
+
+.subckt sky130_fd_pr__diode_pw2nd_05v5 N P area=1e12 perim=1e6
+D0 N P sky130_fd_pr__diode_pw2nd_05v5 area={area} pj={perim}
+.ends
+
+.subckt sky130_fd_pr__diode_pw2nd_11v0 N P area=1e12 perim=1e6
+D0 N P sky130_fd_pr__diode_pw2nd_11v0 area={area} pj={perim}
+.ends
+
+.subckt sky130_fd_pr__diode_pd2nw_05v5_lvt N P area=1e12 perim=1e6
+D0 N P sky130_fd_pr__diode_pd2nw_05v5_lvt area={area} pj={perim}
+.ends
+
+.subckt sky130_fd_pr__diode_pd2nw_05v5_hvt N P area=1e12 perim=1e6
+D0 N P sky130_fd_pr__diode_pd2nw_05v5_hvt area={area} pj={perim}
+.ends
+
+.subckt sky130_fd_pr__diode_pd2nw_05v5 N P area=1e12 perim=1e6
+D0 N P sky130_fd_pr__diode_pd2nw_05v5 area={area} pj={perim}
+.ends
+
+.subckt sky130_fd_pr__diode_pd2nw_11v0 N P area=1e12 perim=1e6
+D0 N P sky130_fd_pr__diode_pd2nw_11v0 area={area} pj={perim}
+.ends
+
 * Subcircuit definition HV diffusion resistors
 
 .subckt sky130_fd_pr__res_generic_nd__hv t1 t2 b w=1 l=1


### PR DESCRIPTION
Added diode subcircuit models to the original discrete model set to be forwards-compatible with the combined models.  Removed the substrate terminal from the PNP devices in the continuous models to make them compatible with the original PNP models, and because the PNP devices have a collector that is the substrate or p-well and therefore do not have a separate substrate terminal.