### PR TITLE
Removed a bad parameter line in models_global.spice

### DIFF
--- a/combined_models/continuous/models_global.spice
+++ b/combined_models/continuous/models_global.spice
@@ -87,7 +87,6 @@
 * Global Matching Monte Carlo driver
 * ----------------------------------
 
-.param mismatch_factor*MC_MM_SWITCH*AGAUSS(0,1.0,1) = 0 mismatch_factor*MC_MM_SWITCH*AGAUSS(0,1.0,1) = 0
 *    statistics{
 *       mismatch{
 *          vary mm_z1 dist=gauss std=mismatch_factor


### PR DESCRIPTION
Removed a bad parameter line that should not have been in the model because it represents a parameter value that has been removed entirely from the model files due to the difference between spectre and ngspice in handling random value variation.  Thanks to Stefan Schippers for pointing it out.  Ngspice seems to ignore the bad line, while Xyce halts with an error.  So it breaks Xyce compatibility.