### PR TITLE
Changed all of the model level 3 diode reverse breakdown voltage parameter names from "vb" to "bv"

### DIFF
--- a/cells/diode_pd2nw_05v5/sky130_fd_pr__diode_pd2nw_05v5.model.spice
+++ b/cells/diode_pd2nw_05v5/sky130_fd_pr__diode_pd2nw_05v5.model.spice
@@ -35,7 +35,7 @@
 + rs = 600 ; Units: ohm (ohm/meter^2 if area defined)
 + ik = '4.76e-008/1e-12' ; Units: amper/meter^2
 + ikr = '0/1e-12' ; Units: amper/meter^2
-+ vb = 12.69 ; Units: volt
++ bv = 12.69 ; Units: volt
 + ibv = 0.00106 ; Units: amper
 + trs = 0 ; Units: 1/coulomb
 + eg = 1.05 ; Units: electron-volt

--- a/cells/diode_pd2nw_05v5_hvt/sky130_fd_pr__diode_pd2nw_05v5_hvt.model.spice
+++ b/cells/diode_pd2nw_05v5_hvt/sky130_fd_pr__diode_pd2nw_05v5_hvt.model.spice
@@ -35,7 +35,7 @@
 + rs = 600 ; Units: ohm (ohm/meter^2 if area defined)
 + ik = '4.76e-008/1e-12' ; Units: amper/meter^2
 + ikr = '0/1e-12' ; Units: amper/meter^2
-+ vb = 12.8 ; Units: volt
++ bv = 12.8 ; Units: volt
 + ibv = 0.00106 ; Units: amper
 + trs = 0 ; Units: 1/coulomb
 + eg = 1.05 ; Units: electron-volt

--- a/cells/diode_pd2nw_05v5_lvt/sky130_fd_pr__diode_pd2nw_05v5_lvt.model.spice
+++ b/cells/diode_pd2nw_05v5_lvt/sky130_fd_pr__diode_pd2nw_05v5_lvt.model.spice
@@ -35,7 +35,7 @@
 + rs = 600 ; Units: ohm (ohm/meter^2 if area defined)
 + ik = '4.76e-008/1e-12' ; Units: amper/meter^2
 + ikr = '0/1e-12' ; Units: amper/meter^2
-+ vb = 12.69 ; Units: volt
++ bv = 12.69 ; Units: volt
 + ibv = 0.00106 ; Units: amper
 + trs = 0 ; Units: 1/coulomb
 + eg = 1.05 ; Units: electron-volt

--- a/cells/diode_pd2nw_11v0/sky130_fd_pr__diode_pd2nw_11v0.model.spice
+++ b/cells/diode_pd2nw_11v0/sky130_fd_pr__diode_pd2nw_11v0.model.spice
@@ -35,7 +35,7 @@
 + rs = 600 ; Units: ohm (ohm/meter^2 if area defined)
 + ik = '4.76e-008/1e-12' ; Units: amper/meter^2
 + ikr = '0/1e-12' ; Units: amper/meter^2
-+ vb = 12.69 ; Units: volt
++ bv = 12.69 ; Units: volt
 + ibv = 0.00106 ; Units: amper
 + trs = 0 ; Units: 1/coulomb
 + eg = 1.05 ; Units: electron-volt

--- a/cells/diode_pd2nw_11v0/sky130_fd_pr__diode_pd2nw_11v0_no_rs.model.spice
+++ b/cells/diode_pd2nw_11v0/sky130_fd_pr__diode_pd2nw_11v0_no_rs.model.spice
@@ -35,7 +35,7 @@
 + rs = 0 ; Units: ohm (ohm/meter^2 if area defined)
 + ik = '4.76e-008/1e-12' ; Units: amper/meter^2
 + ikr = '0/1e-12' ; Units: amper/meter^2
-+ vb = 12.69 ; Units: volt
++ bv = 12.69 ; Units: volt
 + ibv = 0.00106 ; Units: amper
 + trs = 0 ; Units: 1/coulomb
 + eg = 1.05 ; Units: electron-volt

--- a/cells/diode_pw2nd_05v5/sky130_fd_pr__diode_pw2nd_05v5.model.spice
+++ b/cells/diode_pw2nd_05v5/sky130_fd_pr__diode_pw2nd_05v5.model.spice
@@ -35,7 +35,7 @@
 + rs = 981 ; Units: ohm (ohm/meter^2 if area defined)
 + ik = '1.3e-009/1e-12' ; Units: amper/meter^2
 + ikr = '0/1e-12' ; Units: amper/meter^2
-+ vb = 11.7 ; Units: volt
++ bv = 11.7 ; Units: volt
 + ibv = 0.00106 ; Units: amper
 + trs = 0 ; Units: 1/coulomb
 + eg = 1.05 ; Units: electron-volt

--- a/cells/diode_pw2nd_05v5/sky130_fd_pr__diode_pw2nd_05v5__extended_drain.model.spice
+++ b/cells/diode_pw2nd_05v5/sky130_fd_pr__diode_pw2nd_05v5__extended_drain.model.spice
@@ -38,7 +38,7 @@
 + rs = 981 ; Units: ohm (ohm/meter^2 if area defined)
 + ik = '1.3e-009/1e-12' ; Units: amper/meter^2
 + ikr = '0/1e-12' ; Units: amper/meter^2
-+ vb = 11.7 ; Units: volt
++ bv = 11.7 ; Units: volt
 + ibv = 0.00106 ; Units: amper
 + trs = 0 ; Units: 1/coulomb
 + eg = 1.05 ; Units: electron-volt

--- a/cells/diode_pw2nd_05v5_lvt/sky130_fd_pr__diode_pw2nd_05v5_lvt.model.spice
+++ b/cells/diode_pw2nd_05v5_lvt/sky130_fd_pr__diode_pw2nd_05v5_lvt.model.spice
@@ -35,7 +35,7 @@
 + rs = 981 ; Units: ohm (ohm/meter^2 if area defined)
 + ik = '1.3e-009/1e-12' ; Units: amper/meter^2
 + ikr = '0/1e-12' ; Units: amper/meter^2
-+ vb = 11.9 ; Units: volt
++ bv = 11.9 ; Units: volt
 + ibv = 0.00106 ; Units: amper
 + trs = 0 ; Units: 1/coulomb
 + eg = 1.05 ; Units: electron-volt

--- a/cells/diode_pw2nd_05v5_nvt/sky130_fd_pr__diode_pw2nd_05v5_nvt.model.spice
+++ b/cells/diode_pw2nd_05v5_nvt/sky130_fd_pr__diode_pw2nd_05v5_nvt.model.spice
@@ -35,7 +35,7 @@
 + rs = 600 ; Units: ohm (ohm/meter^2 if area defined)
 + ik = '4.76e-008/1e-12' ; Units: amper/meter^2
 + ikr = '0/1e-12' ; Units: amper/meter^2
-+ vb = 12.69 ; Units: volt
++ bv = 12.69 ; Units: volt
 + ibv = 0.00106 ; Units: amper
 + trs = 0 ; Units: 1/coulomb
 + eg = 1.05 ; Units: electron-volt

--- a/cells/diode_pw2nd_11v0/sky130_fd_pr__diode_pw2nd_11v0.model.spice
+++ b/cells/diode_pw2nd_11v0/sky130_fd_pr__diode_pw2nd_11v0.model.spice
@@ -35,7 +35,7 @@
 + rs = 981 ; Units: ohm (ohm/meter^2 if area defined)
 + ik = '1.3e-009/1e-12' ; Units: amper/meter^2
 + ikr = '0/1e-12' ; Units: amper/meter^2
-+ vb = 12.636 ; Units: volt
++ bv = 12.636 ; Units: volt
 + ibv = 0.00106 ; Units: amper
 + trs = 0 ; Units: 1/coulomb
 + eg = 0.92 ; Units: electron-volt

--- a/cells/diode_pw2nd_11v0/sky130_fd_pr__diode_pw2nd_11v0_no_rs.model.spice
+++ b/cells/diode_pw2nd_11v0/sky130_fd_pr__diode_pw2nd_11v0_no_rs.model.spice
@@ -35,7 +35,7 @@
 + rs = 0 ; Units: ohm (ohm/meter^2 if area defined)
 + ik = '1.3e-009/1e-12' ; Units: amper/meter^2
 + ikr = '0/1e-12' ; Units: amper/meter^2
-+ vb = 12.636 ; Units: volt
++ bv = 12.636 ; Units: volt
 + ibv = 0.00106 ; Units: amper
 + trs = 0 ; Units: 1/coulomb
 + eg = 0.92 ; Units: electron-volt

--- a/cells/nfet_20v0_nvt/sky130_fd_pr__nfet_20v0_nvt__parasitic__diode_ps2dn.model.spice
+++ b/cells/nfet_20v0_nvt/sky130_fd_pr__nfet_20v0_nvt__parasitic__diode_ps2dn.model.spice
@@ -37,7 +37,7 @@
 + rs = 900 ; Units: ohm (ohm/meter^2 if area defined)
 + ik = '2.08e-009/1e-12' ; Units: amper/meter^2
 + ikr = '0/1e-12' ; Units: amper/meter^2
-+ vb = 'sky130_fd_pr__nfet_20v0__vb' ; Units: volt
++ bv = 'sky130_fd_pr__nfet_20v0__vb' ; Units: volt
 + ibv = 0.00106 ; Units: amper
 + trs = 0 ; Units: 1/coulomb
 + eg = 1.17 ; Units: electron-volt

--- a/cells/nfet_20v0_zvt/sky130_fd_pr__nfet_20v0_zvt__parasitic__diode_ps2dn__extended_drain.model.spice
+++ b/cells/nfet_20v0_zvt/sky130_fd_pr__nfet_20v0_zvt__parasitic__diode_ps2dn__extended_drain.model.spice
@@ -42,7 +42,7 @@
 + rs = 900 ; Units: ohm (ohm/meter^2 if area defined)
 + ik = '2.08e-009/1e-12' ; Units: amper/meter^2
 + ikr = '0/1e-12' ; Units: amper/meter^2
-+ vb = 'sky130_fd_pr__nfet_20v0_zvt__vb' ; Units: volt
++ bv = 'sky130_fd_pr__nfet_20v0_zvt__vb' ; Units: volt
 + ibv = 0.00106 ; Units: amper
 + trs = 0 ; Units: 1/coulomb
 + eg = 1.17 ; Units: electron-volt

--- a/cells/pfet_20v0/sky130_fd_pr__pfet_20v0__parasitic__diode_pw2dn.model.spice
+++ b/cells/pfet_20v0/sky130_fd_pr__pfet_20v0__parasitic__diode_pw2dn.model.spice
@@ -48,7 +48,7 @@
 + rs = 900 ; Units: ohm (ohm/meter^2 if area defined)
 + ik = '2.08e-009/1e-12' ; Units: amper/meter^2
 + ikr = '0/1e-12' ; Units: amper/meter^2
-+ vb = 'sky130_fd_pr__pfet_20v0__vb' ; Units: volt
++ bv = 'sky130_fd_pr__pfet_20v0__vb' ; Units: volt
 + ibv = 0.00106 ; Units: amper
 + trs = 0 ; Units: 1/coulomb
 + xti = 3.0

--- a/cells/pfet_g5v0d16v0/sky130_fd_pr__pfet_g5v0d16v0__parasitic__diode_pw2dn.model.spice
+++ b/cells/pfet_g5v0d16v0/sky130_fd_pr__pfet_g5v0d16v0__parasitic__diode_pw2dn.model.spice
@@ -35,7 +35,7 @@
 + rs = 900 ; Units: ohm (ohm/meter^2 if area defined)
 + ik = '2.08e-009/1e-12' ; Units: amper/meter^2
 + ikr = '0/1e-12' ; Units: amper/meter^2
-+ vb = 17.95 ; Units: volt
++ bv = 17.95 ; Units: volt
 + ibv = 0.00106 ; Units: amper
 + trs = 0 ; Units: 1/coulomb
 + eg = 1.17 ; Units: electron-volt

--- a/combined_models/continuous/models_diodes.spice
+++ b/combined_models/continuous/models_diodes.spice
@@ -71,7 +71,7 @@ Dsky130_fd_pr__model__parasitic__diode_ps2dn__extended_drain a c sky130_fd_pr__m
 + ik = {2.08e-009/1e-12}
 + ikr = 0
 ******set to 40V so design can evaluate circuits using up to 36V
-+ vb = {sky130_fd_pr__nfet_20v0_zvt_vb}
++ bv = {sky130_fd_pr__nfet_20v0_zvt_vb}
 + ibv = 0.00106
 + trs = 0
 + eg = 1.17
@@ -148,7 +148,7 @@ Dsky130_fd_pr__model__parasitic__diode_ps2dn a c sky130_fd_pr__model__parasitic_
 + rs = {900*1e-12}
 + ik = {2.08e-009/1e-12}
 + ikr = {0/1e-12}
-+ vb = {16.95/(1+0.2*(sw_func_dnw_sub_cj-1))}
++ bv = {16.95/(1+0.2*(sw_func_dnw_sub_cj-1))}
 + ibv = 0.00106
 + trs = 0
 + eg = 1.17
@@ -225,7 +225,7 @@ Dsky130_fd_pr__model__parasitic__diode_pw2dn_defet a c diodeint area = {area} pj
 + ik = {2.08e-009/1e-12}
 + ikr = {0/1e-12}
 ******set to 40V so design can evaluate circuits using up to 36V
-+ vb = {26/(1+0.3*(sw_func_pw_dnw_cj-1))}
++ bv = {26/(1+0.3*(sw_func_pw_dnw_cj-1))}
 + ibv = 0.00106
 + trs = 0
 + xti = 3.0
@@ -301,7 +301,7 @@ Dsky130_fd_pr__model__parasitic__diode_pw2dn a c diodeint area = {area} pj = {pe
 + rs = {900*1e-12}
 + ik = {2.08e-009/1e-12}
 + ikr = {0/1e-12}
-+ vb = {16.38/(1+0.3*(sw_func_pw_dnw_cj-1))}
++ bv = {16.38/(1+0.3*(sw_func_pw_dnw_cj-1))}
 + ibv = 0.00106
 + trs = 0
 + eg = 1.17
@@ -376,7 +376,7 @@ Dsky130_fd_pr__diode_pw2nd_05v5_defet a c diodeint area = {area} pj = {perim}
 + rs = {981*1e-12}
 + ik = {1.3e-009/1e-12}
 + ikr = {0/1e-12}
-+ vb = {11.7/sw_func_nsd_pw_cj}
++ bv = {11.7/sw_func_nsd_pw_cj}
 + ibv = 0.00106
 + trs = 0
 + eg = 1.05
@@ -493,7 +493,7 @@ Dsky130_fd_pr__diode_pw2nd_05v5_lvt a c diodeint area = {area} pj = {perim}
 + rs = {981*1e-12}
 + ik = {1.3e-009/1e-12}
 + ikr = {0/1e-12}
-+ vb = {11.9/sw_func_nsd_pw_cj}
++ bv = {11.9/sw_func_nsd_pw_cj}
 + ibv = 0.00106
 + trs = 0
 + eg = 1.05
@@ -567,7 +567,7 @@ Dsky130_fd_pr__diode_pw2nd_05v5_nvt a c diodeint area = {area} pj = {perim}
 + rs = {600*1e-12}
 + ik = {4.76e-008/1e-12}
 + ikr = {0/1e-12}
-+ vb = {12.69/sw_func_nsd_pw_cj}
++ bv = {12.69/sw_func_nsd_pw_cj}
 + ibv = 0.00106
 + trs = 0
 + eg = 1.05
@@ -643,7 +643,7 @@ Dsky130_fd_pr__diode_pw2nd_05v5 a c ndiode area = {area} pj = {perim}
 + rs = {rs_int}
 + ik = {1.3e-009/1e-12}
 + ikr = 0
-+ vb = {11.7/sw_func_nsd_pw_cj}
++ bv = {11.7/sw_func_nsd_pw_cj}
 + ibv = 0.00106
 + trs = 0
 + eg = 1.05
@@ -719,7 +719,7 @@ Dsky130_fd_pr__diode_pw2nd_11v0 a c ndiode_h area = {area} pj = {perim}
 + rs = {rs_int}
 + ik = {1.3e-009/1e-12}
 + ikr = {0/1e-12}
-+ vb = {12.636/sw_func_nsd_pw_cj}
++ bv = {12.636/sw_func_nsd_pw_cj}
 + ibv = 0.00106
 + trs = 0
 + eg = 0.92
@@ -794,7 +794,7 @@ Dsky130_fd_pr__model__parasitic__diode_pd2nw a c diodeint area = {area} pj = {pe
 + rs = {900*1e-12}
 + ik = {2.08e-009/1e-12}
 + ikr = {0/1e-12}
-+ vb = {16.848/sw_func_nw_pw_cj}
++ bv = {16.848/sw_func_nw_pw_cj}
 + ibv = 0.00106
 + trs = 0
 + eg = 1.17
@@ -870,7 +870,7 @@ Dsky130_fd_pr__photodiode a c diodeint area = {area} pj = {perim}
 + rs = {900*1e-12}
 + ik = {2.08e-009/1e-12}
 + ikr = {0/1e-12}
-+ vb = {16.95/sw_func_psd_nw_cj}
++ bv = {16.95/sw_func_psd_nw_cj}
 + ibv = 0.00106
 + trs = 0
 + eg = 1.17
@@ -989,7 +989,7 @@ Dsky130_fd_pr__diode_pd2nw_05v5_hvt a c diodeint area = {area} pj = {perim}
 + rs = {600*1e-12}
 + ik = {4.76e-008/1e-12}
 + ikr = {0/1e-12}
-+ vb = {12.8/sw_func_psd_nw_cj}
++ bv = {12.8/sw_func_psd_nw_cj}
 + ibv = 0.00106
 + trs = 0
 + eg = 1.05
@@ -1065,7 +1065,7 @@ Dsky130_fd_pr__diode_pd2nw_05v5_lvt a c  diodeint area = {area} pj = {perim}
 + rs = {600*1e-12}
 + ik = {4.76e-008/1e-12}
 + ikr = {0/1e-12}
-+ vb = {12.69/sw_func_psd_nw_cj}
++ bv = {12.69/sw_func_psd_nw_cj}
 + ibv = 0.00106
 + trs = 0
 + eg = 1.05
@@ -1142,7 +1142,7 @@ Dsky130_fd_pr__diode_pd2nw_05v5 a c pdiode area = {area} pj = {perim}
 + rs = {rs_int}
 + ik = {4.76e-008/1e-12}
 + ikr = 0
-+ vb = {12.69/sw_func_psd_nw_cj}
++ bv = {12.69/sw_func_psd_nw_cj}
 + ibv = 0.00106
 + trs = 0
 + eg = 1.05
@@ -1218,7 +1218,7 @@ Dsky130_fd_pr__diode_pd2nw_11v0 a c pdiode_h area = {area} pj = {perim}
 + rs = {rs_int}
 + ik = {4.76e-008/1e-12}
 + ikr = 0
-+ vb = {12.69/sw_func_psd_nw_cj}
++ bv = {12.69/sw_func_psd_nw_cj}
 + ibv = 0.00106
 + trs = 0
 + eg = 1.05

--- a/models/parasitics/sky130_fd_pr__model__parasitic__diode_ps2dn.model.spice
+++ b/models/parasitics/sky130_fd_pr__model__parasitic__diode_ps2dn.model.spice
@@ -35,7 +35,7 @@
 + rs = 900 ; Units: ohm (ohm/meter^2 if area defined)
 + ik = '2.08e-009/1e-12' ; Units: amper/meter^2
 + ikr = '0/1e-12' ; Units: amper/meter^2
-+ vb = 16.95 ; Units: volt
++ bv = 16.95 ; Units: volt
 + ibv = 0.00106 ; Units: amper
 + trs = 0 ; Units: 1/coulomb
 + eg = 1.17 ; Units: electron-volt

--- a/models/parasitics/sky130_fd_pr__model__parasitic__diode_ps2dn__extended_drain.model.spice
+++ b/models/parasitics/sky130_fd_pr__model__parasitic__diode_ps2dn__extended_drain.model.spice
@@ -41,7 +41,7 @@
 + rs = 900 ; Units: ohm (ohm/meter^2 if area defined)
 + ik = '2.08e-009/1e-12' ; Units: amper/meter^2
 + ikr = '0/1e-12' ; Units: amper/meter^2
-+ vb = 'sky130_fd_pr__nfet_20v0__vb' ; Units: volt
++ bv = 'sky130_fd_pr__nfet_20v0__vb' ; Units: volt
 + ibv = 0.00106 ; Units: amper
 + trs = 0 ; Units: 1/coulomb
 + eg = 1.17 ; Units: electron-volt

--- a/models/parasitics/sky130_fd_pr__model__parasitic__diode_ps2nw.model.spice
+++ b/models/parasitics/sky130_fd_pr__model__parasitic__diode_ps2nw.model.spice
@@ -35,7 +35,7 @@
 + rs = 900 ; Units: ohm (ohm/meter^2 if area defined)
 + ik = '2.08e-009/1e-12' ; Units: amper/meter^2
 + ikr = '0/1e-12' ; Units: amper/meter^2
-+ vb = 16.848 ; Units: volt
++ bv = 16.848 ; Units: volt
 + ibv = 0.00106 ; Units: amper
 + trs = 0 ; Units: 1/coulomb
 + eg = 1.17 ; Units: electron-volt

--- a/models/parasitics/sky130_fd_pr__model__parasitic__diode_ps2nw_noresistor.model.spice
+++ b/models/parasitics/sky130_fd_pr__model__parasitic__diode_ps2nw_noresistor.model.spice
@@ -35,7 +35,7 @@
 + rs = 0 ; Units: ohm (ohm/meter^2 if area defined)
 + ik = '2.08e-009/1e-12' ; Units: amper/meter^2
 + ikr = '0/1e-12' ; Units: amper/meter^2
-+ vb = 16.848 ; Units: volt
++ bv = 16.848 ; Units: volt
 + ibv = 0.00106 ; Units: amper
 + trs = 0 ; Units: 1/coulomb
 + eg = 1.17 ; Units: electron-volt

--- a/models/parasitics/sky130_fd_pr__model__parasitic__diode_pw2dn.model.spice
+++ b/models/parasitics/sky130_fd_pr__model__parasitic__diode_pw2dn.model.spice
@@ -35,7 +35,7 @@
 + rs = 900 ; Units: ohm (ohm/meter^2 if area defined)
 + ik = '2.08e-009/1e-12' ; Units: amper/meter^2
 + ikr = '0/1e-12' ; Units: amper/meter^2
-+ vb = 16.38 ; Units: volt
++ bv = 16.38 ; Units: volt
 + ibv = 0.00106 ; Units: amper
 + trs = 0 ; Units: 1/coulomb
 + eg = 1.17 ; Units: electron-volt

--- a/models/parasitics/sky130_fd_pr__model__parasitic__diode_pw2dn__extended_drain.model.spice
+++ b/models/parasitics/sky130_fd_pr__model__parasitic__diode_pw2dn__extended_drain.model.spice
@@ -42,7 +42,7 @@
 + rs = 900 ; Units: ohm (ohm/meter^2 if area defined)
 + ik = '2.08e-009/1e-12' ; Units: amper/meter^2
 + ikr = '0/1e-12' ; Units: amper/meter^2
-+ vb = 'sky130_fd_pr__nfet_20v0_iso__vb' ; Units: volt
++ bv = 'sky130_fd_pr__nfet_20v0_iso__vb' ; Units: volt
 + ibv = 0.00106 ; Units: amper
 + trs = 0 ; Units: 1/coulomb
 + xti = 3.0

--- a/models/parasitics/sky130_fd_pr__model__parasitic__diode_pw2dn_noresistor.model.spice
+++ b/models/parasitics/sky130_fd_pr__model__parasitic__diode_pw2dn_noresistor.model.spice
@@ -35,7 +35,7 @@
 + rs = 0 ; Units: ohm (ohm/meter^2 if area defined)
 + ik = '2.08e-009/1e-12' ; Units: amper/meter^2
 + ikr = '0/1e-12' ; Units: amper/meter^2
-+ vb = 16.38 ; Units: volt
++ bv = 16.38 ; Units: volt
 + ibv = 0.00106 ; Units: amper
 + trs = 0 ; Units: 1/coulomb
 + eg = 1.17 ; Units: electron-volt


### PR DESCRIPTION
Changed all of the model level 3 diode reverse breakdown voltage parameter names from "vb" to "bv", because ngspice currently does not support all the parameter name variations for the level 3 model.  There is a pending pull request to fix the issue in ngspice.  However, the change in the primitive device repository can be put into effect immediately and should fix simulations with ngspice while not affecting simulations with any tool that has proper support for level 3 diodes.

Thanks to Pat Deegan for finding the issue and the solution, and to generating a patch for ngspice.