### PR TITLE
fix res_generic_po dw parameter expression

### DIFF
--- a/models/sky130_fd_pr__model__r+c.model.spice
+++ b/models/sky130_fd_pr__model__r+c.model.spice
@@ -131,7 +131,7 @@
 .model sky130_fd_pr__res_generic_pd r tc1r = {tc1rsp} tc2r = {tc2rsp} rsh = {rdp} dw = {"-tol_pfom/2-pfom_dw/2"} tnom = 30.0
 .model sky130_fd_pr__res_generic_nd__hv r tc1r = {tc1rsn_h} tc2r = {tc2rsn_h} rsh = {rdn_hv} dw = {"-tol_nfom/2-nfom_dw/2"} tnom = 30.0
 .model sky130_fd_pr__res_generic_pd__hv r tc1r = {tc1rsp_h} tc2r = {tc2rsp_h} rsh = {rdp_hv} dw = {"-tol_pfom/2-pfom_dw/2"} tnom = 30.0
-.model sky130_fd_pr__res_generic_po       r tc1r=tc1rsgpu   tc2r=tc2rsgpu   rsh=rp1   dw="-tol_poly/2-poly_dw/2" tnom=30
+.model sky130_fd_pr__res_generic_po       r tc1r=tc1rsgpu   tc2r=tc2rsgpu   rsh=rp1   dw = {"-tol_poly/2-poly_dw/2"} tnom=30
 .model sky130_fd_pr__res_generic_nw r tc1r = {tc1rsnw} tc2r = {tc2rsnw} rsh = {rnw} dw = {"-tol_nw/2"} tnom = 30.0
 .model sky130_fd_pr__res_generic_l1 r tc1r = {tc1rl1} tc2r = {tc2rl1} rsh = {rl1} dw = {"-tol_li/2-li_dw/2"} tnom = 30.0
 .model sky130_fd_pr__res_generic_m1 r tc1r = {tc1rm1} tc2r = {tc2rm1} rsh = {rm1} dw = {"-tol_m1/2-m1_dw/2"} tnom = 30.0


### PR DESCRIPTION
One additional change in conjunction with yesterday's commit: The model for the generic poly resistor needs the same braces around the expression for delta width used in the other devices. If the braces are missing, then the expression is not parsed correctly by ngspice.