### PR TITLE
Add new spiceinit file

### DIFF
--- a/models/spiceinit
+++ b/models/spiceinit
@@ -1,0 +1,8 @@
+* .spiceinit for use with Skywater PDK and ngspice KLU
+set ngbehavior=hsa     ; set compatibility for reading PDK libs
+set skywaterpdk        ; skip some checks for faster lib loading
+set ng_nomodcheck      ; don't check the model parameters
+set num_threads=8      ; CPU processor cores available
+option noinit          ; don't print operating point data
+option klu             ; select KLU as matrix solver
+* optran 0 0 0 100p 2n 0 ; don't use dc operating point, but transient op


### PR DESCRIPTION
Rename `spinit` to `spiceinit`, as `spinit` is only loaded relative to the binary. Update its content with the one recommended by ngspice: https://ngspice.sourceforge.io/applic.html

The file must be copied or linked by the user to where it is needed (either the user's home directory or the simulation directory) and renamed to `.spiceinit`.

The `optran` option was removed as it needs to be tweaked depending on the design.