### PR TITLE
Fixed the two incorrect paths to the NPN model files.

### DIFF
--- a/models/corners/ff.spice
+++ b/models/corners/ff.spice
@@ -26,6 +26,6 @@
 .include "../../cells/pfet_20v0/sky130_fd_pr__pfet_20v0__fs_discrete.corner.spice"
 .include "../../cells/nfet_20v0/sky130_fd_pr__nfet_20v0__sf_discrete.corner.spice"
 .include "../../cells/nfet_20v0_nvt/sky130_fd_pr__nfet_20v0_nvt__sf_discrete.corner.spice"
-.include "../../cells/nfet_05v5/sky130_fd_pr__npn_05v5__f.corner.spice"
+.include "../../cells/npn_05v5/sky130_fd_pr__npn_05v5__f.corner.spice"
 .include "../all.spice"
 .include "ff/rf.spice"

--- a/models/corners/ss.spice
+++ b/models/corners/ss.spice
@@ -26,6 +26,6 @@
 .include "../../cells/pfet_20v0/sky130_fd_pr__pfet_20v0__sf_discrete.corner.spice"
 .include "../../cells/nfet_20v0/sky130_fd_pr__nfet_20v0__fs_discrete.corner.spice"
 .include "../../cells/nfet_20v0_nvt/sky130_fd_pr__nfet_20v0_nvt__fs_discrete.corner.spice"
-.include "../../cells/nfet_05v5/sky130_fd_pr__npn_05v5__s.corner.spice"
+.include "../../cells/npn_05v5/sky130_fd_pr__npn_05v5__s.corner.spice"
 .include "../all.spice"
 .include "ss/rf.spice"


### PR DESCRIPTION
Fixed the two incorrect paths to the NPN model files, as pointed out by Kareem alGalaly in github issue #30.
Note that open_pdks ends up correcting this error inadvertently by modifying the paths for the target install location, so this change does not affect any compiled distributions of the PDK, such as volare.